### PR TITLE
feat(server): configurable CORS origins for external hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ via available system package managers (`apt`, `dnf`, `yum`, `pacman`, `zypper`,
 
 ```
 nullhub                          # Start server + open browser
-nullhub serve [--port N]         # Start server without browser
+nullhub serve [--host H] [--port N]
+               [--allowed-origin ORIGIN] ...
+                                 # Start server. Repeat --allowed-origin to
+                                 # authorize extra CORS origins (e.g. a
+                                 # Tailscale domain). Origins may also come
+                                 # from NULLHUB_ALLOWED_ORIGINS as a
+                                 # comma-separated list.
 nullhub version | -v | --version # Print version
 
 nullhub install <component>      # Terminal wizard

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -231,24 +231,42 @@ fn parseServe(allocator: std.mem.Allocator, args: *ArgIterator) Command {
             opts.no_open = true;
         } else if (std.mem.eql(u8, arg, "--allowed-origin")) {
             if (args.next()) |val| {
-                appendOriginIfValid(allocator, &origins, val);
+                if (!appendOriginIfValid(allocator, &origins, val)) {
+                    std.debug.print(
+                        "nullhub: ignoring invalid --allowed-origin value: {s}\n",
+                        .{val},
+                    );
+                }
             }
         }
     }
     if (origins.items.len > 0) {
-        opts.extra_allowed_origins = origins.toOwnedSlice(allocator) catch &.{};
+        opts.extra_allowed_origins = origins.toOwnedSlice(allocator) catch blk: {
+            std.debug.print("nullhub: dropped --allowed-origin list (out of memory)\n", .{});
+            break :blk &.{};
+        };
     }
     return .{ .serve = opts };
 }
 
+/// Append a validated, allocator-owned copy of `raw` to `list`. Returns
+/// `true` if the value was accepted, `false` if it was rejected (invalid
+/// input or OOM). The caller is responsible for freeing each appended
+/// string (callers that feed origin lists typically reuse a single
+/// allocator and free the entire list at shutdown).
 fn appendOriginIfValid(
     allocator: std.mem.Allocator,
     list: *std.ArrayListUnmanaged([]const u8),
     raw: []const u8,
-) void {
+) bool {
     const trimmed = std.mem.trim(u8, raw, " \t\r\n");
-    if (!isValidOrigin(trimmed)) return;
-    list.append(allocator, trimmed) catch return;
+    if (!isValidOrigin(trimmed)) return false;
+    const owned = allocator.dupe(u8, trimmed) catch return false;
+    list.append(allocator, owned) catch {
+        allocator.free(owned);
+        return false;
+    };
+    return true;
 }
 
 fn isValidOrigin(origin: []const u8) bool {
@@ -264,17 +282,23 @@ fn isValidOrigin(origin: []const u8) bool {
 }
 
 /// Parse a comma-separated list of origins (e.g. from an environment
-/// variable) and append any valid entries to `list`. Invalid entries are
-/// silently skipped so a bad value cannot prevent nullhub from starting.
+/// variable) and append any valid entries to `list`. Each accepted entry is
+/// copied into `allocator` so the caller may free `csv` afterwards. Returns
+/// the number of non-empty entries that were rejected as invalid so the
+/// caller can surface a diagnostic.
 pub fn appendOriginsFromCsv(
     allocator: std.mem.Allocator,
     list: *std.ArrayListUnmanaged([]const u8),
     csv: []const u8,
-) void {
+) usize {
+    var skipped: usize = 0;
     var it = std.mem.splitScalar(u8, csv, ',');
     while (it.next()) |part| {
-        appendOriginIfValid(allocator, list, part);
+        const trimmed = std.mem.trim(u8, part, " \t\r\n");
+        if (trimmed.len == 0) continue;
+        if (!appendOriginIfValid(allocator, list, trimmed)) skipped += 1;
     }
+    return skipped;
 }
 
 fn parseStatus(args: *ArgIterator) Command {
@@ -570,11 +594,32 @@ test "isValidOrigin accepts scheme+host, rejects malformed" {
 
 test "appendOriginsFromCsv skips blanks and invalid entries" {
     var list: std.ArrayListUnmanaged([]const u8) = .{};
-    defer list.deinit(std.testing.allocator);
-    appendOriginsFromCsv(std.testing.allocator, &list, "https://hub.tailnet.ts.net, ,not-a-url,http://10.0.0.1:19800");
+    defer {
+        for (list.items) |item| std.testing.allocator.free(item);
+        list.deinit(std.testing.allocator);
+    }
+    const skipped = appendOriginsFromCsv(
+        std.testing.allocator,
+        &list,
+        "https://hub.tailnet.ts.net, ,not-a-url,http://10.0.0.1:19800",
+    );
+    try std.testing.expectEqual(@as(usize, 1), skipped);
     try std.testing.expectEqual(@as(usize, 2), list.items.len);
     try std.testing.expectEqualStrings("https://hub.tailnet.ts.net", list.items[0]);
     try std.testing.expectEqualStrings("http://10.0.0.1:19800", list.items[1]);
+}
+
+test "appendOriginsFromCsv copies entries so the source can be freed" {
+    const csv = try std.testing.allocator.dupe(u8, "https://hub.tailnet.ts.net");
+    var list: std.ArrayListUnmanaged([]const u8) = .{};
+    defer {
+        for (list.items) |item| std.testing.allocator.free(item);
+        list.deinit(std.testing.allocator);
+    }
+    _ = appendOriginsFromCsv(std.testing.allocator, &list, csv);
+    std.testing.allocator.free(csv);
+    try std.testing.expectEqual(@as(usize, 1), list.items.len);
+    try std.testing.expectEqualStrings("https://hub.tailnet.ts.net", list.items[0]);
 }
 
 test "InstallOptions defaults" {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -217,7 +217,7 @@ pub fn parse(allocator: std.mem.Allocator, args: *ArgIterator) Command {
 
 fn parseServe(allocator: std.mem.Allocator, args: *ArgIterator) Command {
     var opts = ServeOptions{};
-    var origins: std.ArrayListUnmanaged([]const u8) = .{};
+    var origins: std.ArrayListUnmanaged([]const u8) = .empty;
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--port")) {
             if (args.next()) |val| {
@@ -242,6 +242,8 @@ fn parseServe(allocator: std.mem.Allocator, args: *ArgIterator) Command {
     }
     if (origins.items.len > 0) {
         opts.extra_allowed_origins = origins.toOwnedSlice(allocator) catch blk: {
+            for (origins.items) |origin| allocator.free(origin);
+            origins.deinit(allocator);
             std.debug.print("nullhub: dropped --allowed-origin list (out of memory)\n", .{});
             break :blk &.{};
         };
@@ -270,15 +272,18 @@ fn appendOriginIfValid(
 }
 
 fn isValidOrigin(origin: []const u8) bool {
-    if (origin.len == 0) return false;
-    if (origin[origin.len - 1] == '/') return false;
-    if (std.mem.startsWith(u8, origin, "http://")) {
-        return origin.len > "http://".len;
+    const parsed = std.Uri.parse(origin) catch return false;
+    if (!std.ascii.eqlIgnoreCase(parsed.scheme, "http") and !std.ascii.eqlIgnoreCase(parsed.scheme, "https")) {
+        return false;
     }
-    if (std.mem.startsWith(u8, origin, "https://")) {
-        return origin.len > "https://".len;
-    }
-    return false;
+
+    const host = parsed.host orelse return false;
+    if (host.isEmpty()) return false;
+    if (parsed.user != null or parsed.password != null) return false;
+    if (!parsed.path.isEmpty()) return false;
+    if (parsed.query != null or parsed.fragment != null) return false;
+
+    return true;
 }
 
 /// Parse a comma-separated list of origins (e.g. from an environment
@@ -585,15 +590,19 @@ test "ServeOptions defaults" {
 test "isValidOrigin accepts scheme+host, rejects malformed" {
     try std.testing.expect(isValidOrigin("http://nullhub.local:19800"));
     try std.testing.expect(isValidOrigin("https://hub.tailnet.ts.net"));
+    try std.testing.expect(isValidOrigin("http://[::1]:19800"));
     try std.testing.expect(!isValidOrigin(""));
     try std.testing.expect(!isValidOrigin("hub.tailnet.ts.net"));
     try std.testing.expect(!isValidOrigin("ftp://example.com"));
     try std.testing.expect(!isValidOrigin("https://"));
     try std.testing.expect(!isValidOrigin("https://hub.example/"));
+    try std.testing.expect(!isValidOrigin("https://hub.example/path"));
+    try std.testing.expect(!isValidOrigin("https://hub.example?x=1"));
+    try std.testing.expect(!isValidOrigin("https://user@hub.example"));
 }
 
 test "appendOriginsFromCsv skips blanks and invalid entries" {
-    var list: std.ArrayListUnmanaged([]const u8) = .{};
+    var list: std.ArrayListUnmanaged([]const u8) = .empty;
     defer {
         for (list.items) |item| std.testing.allocator.free(item);
         list.deinit(std.testing.allocator);
@@ -611,7 +620,7 @@ test "appendOriginsFromCsv skips blanks and invalid entries" {
 
 test "appendOriginsFromCsv copies entries so the source can be freed" {
     const csv = try std.testing.allocator.dupe(u8, "https://hub.tailnet.ts.net");
-    var list: std.ArrayListUnmanaged([]const u8) = .{};
+    var list: std.ArrayListUnmanaged([]const u8) = .empty;
     defer {
         for (list.items) |item| std.testing.allocator.free(item);
         list.deinit(std.testing.allocator);

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -10,6 +10,10 @@ pub const ServeOptions = struct {
     port: u16 = access.default_port,
     host: []const u8 = access.default_bind_host,
     no_open: bool = false,
+    /// Additional origins accepted by the API CORS/origin guard, in addition
+    /// to the bind host and built-in local aliases. Each entry is an origin
+    /// of the form `scheme://host[:port]` with no trailing slash.
+    extra_allowed_origins: []const []const u8 = &.{},
 };
 
 pub const InstanceRef = struct {
@@ -133,12 +137,14 @@ pub fn parseInstanceRef(arg: []const u8) ?InstanceRef {
 }
 
 /// Parse CLI arguments into a Command. Expects `args` to have already
-/// consumed the program name (argv[0]).
-pub fn parse(args: *ArgIterator) Command {
+/// consumed the program name (argv[0]). The allocator is used only for
+/// subcommands that collect repeatable flags (e.g. `serve --allowed-origin`);
+/// any allocations live for the remainder of the process.
+pub fn parse(allocator: std.mem.Allocator, args: *ArgIterator) Command {
     const cmd = args.next() orelse return .{ .serve = .{} };
 
     if (std.mem.eql(u8, cmd, "serve")) {
-        return parseServe(args);
+        return parseServe(allocator, args);
     }
     if (std.mem.eql(u8, cmd, "version") or std.mem.eql(u8, cmd, "--version") or std.mem.eql(u8, cmd, "-v")) {
         return .version;
@@ -209,8 +215,9 @@ pub fn parse(args: *ArgIterator) Command {
 
 // ─── Sub-parsers ─────────────────────────────────────────────────────────────
 
-fn parseServe(args: *ArgIterator) Command {
+fn parseServe(allocator: std.mem.Allocator, args: *ArgIterator) Command {
     var opts = ServeOptions{};
+    var origins: std.ArrayListUnmanaged([]const u8) = .{};
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--port")) {
             if (args.next()) |val| {
@@ -222,9 +229,52 @@ fn parseServe(args: *ArgIterator) Command {
             }
         } else if (std.mem.eql(u8, arg, "--no-open")) {
             opts.no_open = true;
+        } else if (std.mem.eql(u8, arg, "--allowed-origin")) {
+            if (args.next()) |val| {
+                appendOriginIfValid(allocator, &origins, val);
+            }
         }
     }
+    if (origins.items.len > 0) {
+        opts.extra_allowed_origins = origins.toOwnedSlice(allocator) catch &.{};
+    }
     return .{ .serve = opts };
+}
+
+fn appendOriginIfValid(
+    allocator: std.mem.Allocator,
+    list: *std.ArrayListUnmanaged([]const u8),
+    raw: []const u8,
+) void {
+    const trimmed = std.mem.trim(u8, raw, " \t\r\n");
+    if (!isValidOrigin(trimmed)) return;
+    list.append(allocator, trimmed) catch return;
+}
+
+fn isValidOrigin(origin: []const u8) bool {
+    if (origin.len == 0) return false;
+    if (origin[origin.len - 1] == '/') return false;
+    if (std.mem.startsWith(u8, origin, "http://")) {
+        return origin.len > "http://".len;
+    }
+    if (std.mem.startsWith(u8, origin, "https://")) {
+        return origin.len > "https://".len;
+    }
+    return false;
+}
+
+/// Parse a comma-separated list of origins (e.g. from an environment
+/// variable) and append any valid entries to `list`. Invalid entries are
+/// silently skipped so a bad value cannot prevent nullhub from starting.
+pub fn appendOriginsFromCsv(
+    allocator: std.mem.Allocator,
+    list: *std.ArrayListUnmanaged([]const u8),
+    csv: []const u8,
+) void {
+    var it = std.mem.splitScalar(u8, csv, ',');
+    while (it.next()) |part| {
+        appendOriginIfValid(allocator, list, part);
+    }
 }
 
 fn parseStatus(args: *ArgIterator) Command {
@@ -414,7 +464,14 @@ pub fn printUsage() void {
         \\Usage: nullhub [command]
         \\
         \\Commands:
-        \\  serve                     Start web UI server (default)
+        \\  serve [--host H] [--port N] [--no-open]
+        \\        [--allowed-origin ORIGIN ...]
+        \\                            Start web UI server (default). Repeat
+        \\                            --allowed-origin to authorize extra
+        \\                            origins (e.g. a Tailscale domain) to
+        \\                            call the API. Origins may also come
+        \\                            from NULLHUB_ALLOWED_ORIGINS as a
+        \\                            comma-separated list.
         \\  install <component>       Install a component
         \\  start <component/name>    Start an instance
         \\  stop <component/name>     Stop an instance
@@ -498,6 +555,26 @@ test "ServeOptions defaults" {
     try std.testing.expectEqual(access.default_port, opts.port);
     try std.testing.expectEqualStrings(access.default_bind_host, opts.host);
     try std.testing.expect(!opts.no_open);
+    try std.testing.expectEqual(@as(usize, 0), opts.extra_allowed_origins.len);
+}
+
+test "isValidOrigin accepts scheme+host, rejects malformed" {
+    try std.testing.expect(isValidOrigin("http://nullhub.local:19800"));
+    try std.testing.expect(isValidOrigin("https://hub.tailnet.ts.net"));
+    try std.testing.expect(!isValidOrigin(""));
+    try std.testing.expect(!isValidOrigin("hub.tailnet.ts.net"));
+    try std.testing.expect(!isValidOrigin("ftp://example.com"));
+    try std.testing.expect(!isValidOrigin("https://"));
+    try std.testing.expect(!isValidOrigin("https://hub.example/"));
+}
+
+test "appendOriginsFromCsv skips blanks and invalid entries" {
+    var list: std.ArrayListUnmanaged([]const u8) = .{};
+    defer list.deinit(std.testing.allocator);
+    appendOriginsFromCsv(std.testing.allocator, &list, "https://hub.tailnet.ts.net, ,not-a-url,http://10.0.0.1:19800");
+    try std.testing.expectEqual(@as(usize, 2), list.items.len);
+    try std.testing.expectEqualStrings("https://hub.tailnet.ts.net", list.items[0]);
+    try std.testing.expectEqualStrings("http://10.0.0.1:19800", list.items[1]);
 }
 
 test "InstallOptions defaults" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -190,7 +190,7 @@ fn resolveAllowedOrigins(
     allocator: std.mem.Allocator,
     from_cli: []const []const u8,
 ) ![]const []const u8 {
-    var list: std.ArrayListUnmanaged([]const u8) = .{};
+    var list: std.ArrayListUnmanaged([]const u8) = .empty;
     errdefer {
         for (list.items) |item| allocator.free(item);
         list.deinit(allocator);

--- a/src/main.zig
+++ b/src/main.zig
@@ -26,7 +26,7 @@ pub fn main(init: std.process.Init) !void {
     defer args.deinit();
     _ = args.next(); // skip program name
 
-    const command = cli.parse(&args);
+    const command = cli.parse(allocator, &args);
 
     switch (command) {
         .version => try printVersionLine(),
@@ -41,6 +41,9 @@ pub fn main(init: std.process.Init) !void {
             defer mgr.deinit();
             var mutex: std_compat.sync.Mutex = .{};
 
+            const allowed_origins = try resolveAllowedOrigins(allocator, opts.extra_allowed_origins);
+            defer allocator.free(allowed_origins);
+
             var srv = try server.Server.init(allocator, opts.host, opts.port, &mgr, &mutex);
             defer srv.deinit();
             var mdns = try mdns_mod.Publisher.init(allocator, paths, opts.host, opts.port);
@@ -48,6 +51,7 @@ pub fn main(init: std.process.Init) !void {
             mdns.start(opts.port);
             srv.setAccessOptions(mdns.accessOptions());
             srv.setAccessPublisher(&mdns);
+            srv.setExtraAllowedOrigins(allowed_origins);
 
             const sup_thread = try std.Thread.spawn(.{}, supervisorLoop, .{ &mgr, &mutex });
             sup_thread.detach();
@@ -170,6 +174,34 @@ fn printStdout(text: []const u8) !void {
     const w = &bw.interface;
     try w.writeAll(text);
     try w.flush();
+}
+
+const allowed_origins_env_var = "NULLHUB_ALLOWED_ORIGINS";
+
+/// Combine CLI-provided `--allowed-origin` entries with any origins supplied
+/// via the `NULLHUB_ALLOWED_ORIGINS` environment variable. The returned
+/// slice is caller-owned and must be freed, but the origin strings it
+/// points at live for the duration of the process and must not be freed
+/// individually.
+fn resolveAllowedOrigins(
+    allocator: std.mem.Allocator,
+    from_cli: []const []const u8,
+) ![]const []const u8 {
+    var list: std.ArrayListUnmanaged([]const u8) = .{};
+    errdefer list.deinit(allocator);
+
+    for (from_cli) |origin| try list.append(allocator, origin);
+
+    if (std_compat.process.getEnvVarOwned(allocator, allowed_origins_env_var)) |csv| {
+        // Origin strings reference slices of `csv`, so leak it for the
+        // process lifetime — it's freed implicitly at exit.
+        cli.appendOriginsFromCsv(allocator, &list, csv);
+    } else |err| switch (err) {
+        error.EnvironmentVariableNotFound => {},
+        else => return err,
+    }
+
+    return list.toOwnedSlice(allocator);
 }
 
 fn supervisorLoop(manager: *manager_mod.Manager, mutex: *std_compat.sync.Mutex) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,7 +42,10 @@ pub fn main(init: std.process.Init) !void {
             var mutex: std_compat.sync.Mutex = .{};
 
             const allowed_origins = try resolveAllowedOrigins(allocator, opts.extra_allowed_origins);
-            defer allocator.free(allowed_origins);
+            // `resolveAllowedOrigins` takes ownership of each item in
+            // `opts.extra_allowed_origins`; only the outer slice remains.
+            if (opts.extra_allowed_origins.len > 0) allocator.free(opts.extra_allowed_origins);
+            defer freeResolvedOrigins(allocator, allowed_origins);
 
             var srv = try server.Server.init(allocator, opts.host, opts.port, &mgr, &mutex);
             defer srv.deinit();
@@ -179,29 +182,42 @@ fn printStdout(text: []const u8) !void {
 const allowed_origins_env_var = "NULLHUB_ALLOWED_ORIGINS";
 
 /// Combine CLI-provided `--allowed-origin` entries with any origins supplied
-/// via the `NULLHUB_ALLOWED_ORIGINS` environment variable. The returned
-/// slice is caller-owned and must be freed, but the origin strings it
-/// points at live for the duration of the process and must not be freed
-/// individually.
+/// via the `NULLHUB_ALLOWED_ORIGINS` environment variable. `from_cli`
+/// entries are already allocator-owned and ownership transfers into the
+/// returned slice; entries parsed from the env var are copied in. The
+/// caller must release the result with `freeResolvedOrigins`.
 fn resolveAllowedOrigins(
     allocator: std.mem.Allocator,
     from_cli: []const []const u8,
 ) ![]const []const u8 {
     var list: std.ArrayListUnmanaged([]const u8) = .{};
-    errdefer list.deinit(allocator);
+    errdefer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
 
     for (from_cli) |origin| try list.append(allocator, origin);
 
     if (std_compat.process.getEnvVarOwned(allocator, allowed_origins_env_var)) |csv| {
-        // Origin strings reference slices of `csv`, so leak it for the
-        // process lifetime — it's freed implicitly at exit.
-        cli.appendOriginsFromCsv(allocator, &list, csv);
+        defer allocator.free(csv);
+        const skipped = cli.appendOriginsFromCsv(allocator, &list, csv);
+        if (skipped > 0) {
+            std.debug.print(
+                "nullhub: {d} invalid entr{s} in {s} ignored\n",
+                .{ skipped, if (skipped == 1) "y" else "ies", allowed_origins_env_var },
+            );
+        }
     } else |err| switch (err) {
         error.EnvironmentVariableNotFound => {},
         else => return err,
     }
 
     return list.toOwnedSlice(allocator);
+}
+
+fn freeResolvedOrigins(allocator: std.mem.Allocator, origins: []const []const u8) void {
+    for (origins) |origin| allocator.free(origin);
+    allocator.free(origins);
 }
 
 fn supervisorLoop(manager: *manager_mod.Manager, mutex: *std_compat.sync.Mutex) void {

--- a/src/server.zig
+++ b/src/server.zig
@@ -1680,6 +1680,17 @@ test "isAllowedCorsOrigin ignores empty extra entries" {
     try std.testing.expect(isAllowedCorsOrigin("https://hub.tailnet.ts.net", "127.0.0.1", 19800, extras));
 }
 
+test "isAllowedCorsOrigin allows extras alongside local aliases when bound to 0.0.0.0" {
+    // Binding to 0.0.0.0 is treated as a local bind (see access.isLocalBindHost),
+    // so local aliases are still accepted — matching how buildAccessUrls
+    // advertises the service locally — and extras layer on top for
+    // external hostnames (Tailscale, custom DNS, etc.).
+    const extras = &[_][]const u8{"https://hub.tailnet.ts.net"};
+    try std.testing.expect(isAllowedCorsOrigin("http://127.0.0.1:19800", "0.0.0.0", 19800, extras));
+    try std.testing.expect(isAllowedCorsOrigin("https://hub.tailnet.ts.net", "0.0.0.0", 19800, extras));
+    try std.testing.expect(!isAllowedCorsOrigin("http://evil.example:19800", "0.0.0.0", 19800, extras));
+}
+
 test "requestOriginAllowed rejects foreign API origins" {
     const evil_raw =
         "GET /api/status HTTP/1.1\r\n" ++

--- a/src/server.zig
+++ b/src/server.zig
@@ -40,6 +40,7 @@ pub const Server = struct {
     access_options: access.Options = .{},
     access_publisher: ?*const mdns_mod.Publisher = null,
     auth_token: ?[]const u8 = null,
+    extra_allowed_origins: []const []const u8 = &.{},
     state: *state_mod.State,
     paths: paths_mod.Paths,
     manager: *manager_mod.Manager,
@@ -98,6 +99,14 @@ pub const Server = struct {
 
     pub fn setAccessPublisher(self: *Server, publisher: *const mdns_mod.Publisher) void {
         self.access_publisher = publisher;
+    }
+
+    /// Configure additional origins (e.g. a Tailscale domain) allowed to call
+    /// the nullhub API in addition to the bind host and the built-in local
+    /// aliases. Each origin must be a scheme+host(+port) string with no
+    /// trailing slash, e.g. `https://hub.tailnet.ts.net`.
+    pub fn setExtraAllowedOrigins(self: *Server, origins: []const []const u8) void {
+        self.extra_allowed_origins = origins;
     }
 
     fn currentAccessOptions(self: *const Server) access.Options {
@@ -425,20 +434,22 @@ pub const Server = struct {
         const method = parts.next() orelse return;
         const target = parts.next() orelse return;
 
+        const extra_origins = self.extra_allowed_origins;
+
         if (std.mem.eql(u8, method, "GET") or std.mem.eql(u8, method, "HEAD")) {
             if (try self.redirectLocationForAliasHost(alloc, raw, target)) |location| {
                 defer alloc.free(location);
-                try sendRedirect(conn.stream, location, raw, self.host, self.port);
+                try sendRedirect(conn.stream, location, raw, self.host, self.port, extra_origins);
                 return;
             }
         }
 
-        if (!requestOriginAllowed(raw, target, self.host, self.port)) {
+        if (!requestOriginAllowed(raw, target, self.host, self.port, extra_origins)) {
             try sendResponse(conn.stream, .{
                 .status = "403 Forbidden",
                 .content_type = "application/json",
                 .body = "{\"error\":\"forbidden origin\"}",
-            }, raw, self.host, self.port);
+            }, raw, self.host, self.port, extra_origins);
             return;
         }
 
@@ -451,7 +462,7 @@ pub const Server = struct {
                 .status = "204 No Content",
                 .content_type = "text/plain",
                 .body = "",
-            }, raw, self.host, self.port);
+            }, raw, self.host, self.port, extra_origins);
             return;
         }
 
@@ -462,7 +473,7 @@ pub const Server = struct {
                     .status = "401 Unauthorized",
                     .content_type = "application/json",
                     .body = "{\"error\":\"unauthorized\"}",
-                }, raw, self.host, self.port);
+                }, raw, self.host, self.port, extra_origins);
                 return;
             }
         }
@@ -475,7 +486,7 @@ pub const Server = struct {
             defer self.mutex.unlock();
             break :blk self.route(alloc, method, target, body);
         };
-        try sendResponse(conn.stream, response, raw, self.host, self.port);
+        try sendResponse(conn.stream, response, raw, self.host, self.port, extra_origins);
     }
 
     fn redirectLocationForAliasHost(self: *const Server, allocator: std.mem.Allocator, raw: []const u8, target: []const u8) !?[]u8 {
@@ -1150,14 +1161,14 @@ fn readBody(raw: []const u8, n: usize, stream: std_compat.net.Stream, alloc: std
     return extractBody(raw);
 }
 
-fn sendResponse(stream: std_compat.net.Stream, response: Response, raw_request: []const u8, bind_host: []const u8, port: u16) !void {
+fn sendResponse(stream: std_compat.net.Stream, response: Response, raw_request: []const u8, bind_host: []const u8, port: u16, extra_origins: []const []const u8) !void {
     var buf: [4096]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
 
     try writer.print("HTTP/1.1 {s}\r\n", .{response.status});
     try writer.print("Content-Type: {s}\r\n", .{response.content_type});
     try writer.print("Content-Length: {d}\r\n", .{response.body.len});
-    try appendCorsHeaders(&writer, raw_request, bind_host, port);
+    try appendCorsHeaders(&writer, raw_request, bind_host, port, extra_origins);
     try writer.writeAll("Connection: close\r\n\r\n");
 
     try net_compat.streamWriteAll(stream, writer.buffered());
@@ -1166,14 +1177,14 @@ fn sendResponse(stream: std_compat.net.Stream, response: Response, raw_request: 
     }
 }
 
-fn sendRedirect(stream: std_compat.net.Stream, location: []const u8, raw_request: []const u8, bind_host: []const u8, port: u16) !void {
+fn sendRedirect(stream: std_compat.net.Stream, location: []const u8, raw_request: []const u8, bind_host: []const u8, port: u16, extra_origins: []const []const u8) !void {
     var buf: [4096]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
 
     try writer.writeAll("HTTP/1.1 308 Permanent Redirect\r\n");
     try writer.print("Location: {s}\r\n", .{location});
     try writer.writeAll("Content-Length: 0\r\n");
-    try appendCorsHeaders(&writer, raw_request, bind_host, port);
+    try appendCorsHeaders(&writer, raw_request, bind_host, port, extra_origins);
     try writer.writeAll("Connection: close\r\n\r\n");
 
     try net_compat.streamWriteAll(stream, writer.buffered());
@@ -1206,38 +1217,44 @@ pub fn extractHeader(raw: []const u8, name: []const u8) ?[]const u8 {
     return null;
 }
 
-fn requestOriginAllowed(raw_request: []const u8, target: []const u8, bind_host: []const u8, port: u16) bool {
+fn requestOriginAllowed(raw_request: []const u8, target: []const u8, bind_host: []const u8, port: u16, extra_origins: []const []const u8) bool {
     if (!std.mem.startsWith(u8, target, "/api/")) return true;
     const origin = extractHeader(raw_request, "Origin") orelse return true;
-    return isAllowedCorsOrigin(origin, bind_host, port);
+    return isAllowedCorsOrigin(origin, bind_host, port, extra_origins);
 }
 
-fn appendCorsHeaders(writer: anytype, raw_request: []const u8, bind_host: []const u8, port: u16) !void {
-    const origin = allowedCorsOrigin(raw_request, bind_host, port) orelse return;
+fn appendCorsHeaders(writer: anytype, raw_request: []const u8, bind_host: []const u8, port: u16, extra_origins: []const []const u8) !void {
+    const origin = allowedCorsOrigin(raw_request, bind_host, port, extra_origins) orelse return;
     try writer.print("Access-Control-Allow-Origin: {s}\r\n", .{origin});
     try writer.writeAll("Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS\r\n");
     try writer.writeAll("Access-Control-Allow-Headers: Content-Type, Authorization\r\n");
     try writer.writeAll("Vary: Origin\r\n");
 }
 
-fn allowedCorsOrigin(raw_request: []const u8, bind_host: []const u8, port: u16) ?[]const u8 {
+fn allowedCorsOrigin(raw_request: []const u8, bind_host: []const u8, port: u16, extra_origins: []const []const u8) ?[]const u8 {
     const origin = extractHeader(raw_request, "Origin") orelse return null;
-    if (!isAllowedCorsOrigin(origin, bind_host, port)) return null;
+    if (!isAllowedCorsOrigin(origin, bind_host, port, extra_origins)) return null;
     return origin;
 }
 
-fn isAllowedCorsOrigin(origin: []const u8, bind_host: []const u8, port: u16) bool {
+fn isAllowedCorsOrigin(origin: []const u8, bind_host: []const u8, port: u16, extra_origins: []const []const u8) bool {
     if (originMatchesHost(origin, bind_host, port)) return true;
-    if (!access.isLocalBindHost(bind_host)) return false;
 
-    inline for (&[_][]const u8{
-        "127.0.0.1",
-        "localhost",
-        "[::1]",
-        access.canonical_local_host,
-        access.public_alias_host,
-    }) |host| {
-        if (originMatchesHost(origin, host, port)) return true;
+    if (access.isLocalBindHost(bind_host)) {
+        inline for (&[_][]const u8{
+            "127.0.0.1",
+            "localhost",
+            "[::1]",
+            access.canonical_local_host,
+            access.public_alias_host,
+        }) |host| {
+            if (originMatchesHost(origin, host, port)) return true;
+        }
+    }
+
+    for (extra_origins) |allowed| {
+        if (allowed.len == 0) continue;
+        if (std.ascii.eqlIgnoreCase(origin, allowed)) return true;
     }
     return false;
 }
@@ -1636,14 +1653,31 @@ test "hostMatchesAliasHost matches bare host and host with port" {
 }
 
 test "isAllowedCorsOrigin allows local aliases for loopback binds" {
-    try std.testing.expect(isAllowedCorsOrigin("http://127.0.0.1:19800", "127.0.0.1", 19800));
-    try std.testing.expect(isAllowedCorsOrigin("http://nullhub.localhost:19800", "127.0.0.1", 19800));
-    try std.testing.expect(isAllowedCorsOrigin("http://nullhub.local:19800", "127.0.0.1", 19800));
+    try std.testing.expect(isAllowedCorsOrigin("http://127.0.0.1:19800", "127.0.0.1", 19800, &.{}));
+    try std.testing.expect(isAllowedCorsOrigin("http://nullhub.localhost:19800", "127.0.0.1", 19800, &.{}));
+    try std.testing.expect(isAllowedCorsOrigin("http://nullhub.local:19800", "127.0.0.1", 19800, &.{}));
 }
 
 test "isAllowedCorsOrigin rejects foreign or mismatched origins" {
-    try std.testing.expect(!isAllowedCorsOrigin("http://evil.example:19800", "127.0.0.1", 19800));
-    try std.testing.expect(!isAllowedCorsOrigin("http://127.0.0.1:19801", "127.0.0.1", 19800));
+    try std.testing.expect(!isAllowedCorsOrigin("http://evil.example:19800", "127.0.0.1", 19800, &.{}));
+    try std.testing.expect(!isAllowedCorsOrigin("http://127.0.0.1:19801", "127.0.0.1", 19800, &.{}));
+}
+
+test "isAllowedCorsOrigin admits configured extra origins for any bind" {
+    const extras = &[_][]const u8{
+        "https://hub.tailnet.ts.net",
+        "http://100.64.0.5:19800",
+    };
+    try std.testing.expect(isAllowedCorsOrigin("https://hub.tailnet.ts.net", "127.0.0.1", 19800, extras));
+    try std.testing.expect(isAllowedCorsOrigin("HTTPS://HUB.TAILNET.TS.NET", "127.0.0.1", 19800, extras));
+    try std.testing.expect(isAllowedCorsOrigin("http://100.64.0.5:19800", "192.168.1.50", 22000, extras));
+    try std.testing.expect(!isAllowedCorsOrigin("http://evil.example", "192.168.1.50", 22000, extras));
+}
+
+test "isAllowedCorsOrigin ignores empty extra entries" {
+    const extras = &[_][]const u8{ "", "https://hub.tailnet.ts.net" };
+    try std.testing.expect(!isAllowedCorsOrigin("", "127.0.0.1", 19800, extras));
+    try std.testing.expect(isAllowedCorsOrigin("https://hub.tailnet.ts.net", "127.0.0.1", 19800, extras));
 }
 
 test "requestOriginAllowed rejects foreign API origins" {
@@ -1651,13 +1685,28 @@ test "requestOriginAllowed rejects foreign API origins" {
         "GET /api/status HTTP/1.1\r\n" ++
         "Host: 127.0.0.1:19800\r\n" ++
         "Origin: http://evil.example:19800\r\n\r\n";
-    try std.testing.expect(!requestOriginAllowed(evil_raw, "/api/status", "127.0.0.1", 19800));
+    try std.testing.expect(!requestOriginAllowed(evil_raw, "/api/status", "127.0.0.1", 19800, &.{}));
 
     const local_raw =
         "GET /api/status HTTP/1.1\r\n" ++
         "Host: 127.0.0.1:19800\r\n" ++
         "Origin: http://nullhub.localhost:19800\r\n\r\n";
-    try std.testing.expect(requestOriginAllowed(local_raw, "/api/status", "127.0.0.1", 19800));
+    try std.testing.expect(requestOriginAllowed(local_raw, "/api/status", "127.0.0.1", 19800, &.{}));
+}
+
+test "requestOriginAllowed honors configured extra origins" {
+    const extras = &[_][]const u8{"https://hub.tailnet.ts.net"};
+    const tailscale_raw =
+        "GET /api/status HTTP/1.1\r\n" ++
+        "Host: hub.tailnet.ts.net\r\n" ++
+        "Origin: https://hub.tailnet.ts.net\r\n\r\n";
+    try std.testing.expect(requestOriginAllowed(tailscale_raw, "/api/status", "127.0.0.1", 19800, extras));
+
+    const foreign_raw =
+        "GET /api/status HTTP/1.1\r\n" ++
+        "Host: hub.tailnet.ts.net\r\n" ++
+        "Origin: https://evil.example\r\n\r\n";
+    try std.testing.expect(!requestOriginAllowed(foreign_raw, "/api/status", "127.0.0.1", 19800, extras));
 }
 
 test "routeWithoutServerMutex keeps orchestration proxy requests off global lock" {


### PR DESCRIPTION
## Summary
- Add `--allowed-origin ORIGIN` (repeatable) to `nullhub serve` and `NULLHUB_ALLOWED_ORIGINS` (comma-separated) so a hub reached via a Tailscale name or other external host is no longer rejected with \"forbidden origin\".
- Thread an `extra_allowed_origins` list through the existing CORS guard (`requestOriginAllowed` / `isAllowedCorsOrigin` / CORS headers); built-in bind-host and local-alias handling are unchanged.
- Validate each origin (scheme + host, no trailing slash), match the `Origin` header case-insensitively, and surface diagnostics for malformed CLI/env values.

Closes #26

## Test plan
- [x] `zig build test --summary all` green (new cases: extras accepted for non-local and `0.0.0.0` binds, empty/invalid entries ignored, CSV copies survive freeing the source buffer, `requestOriginAllowed` honors configured extras).
- [x] Manual: bind to `0.0.0.0`, add Tailscale MagicDNS origin via `--allowed-origin https://hub.tailnet.ts.net`, confirm Hub Web UI works through Tailscale.
- [x] Manual: export `NULLHUB_ALLOWED_ORIGINS="https://hub.tailnet.ts.net, bad"` and confirm the single invalid entry is logged and the valid one is accepted.