### PR TITLE
feat(providers): /models probe for custom endpoint validation

### DIFF
--- a/src/api/instances.zig
+++ b/src/api/instances.zig
@@ -671,9 +671,9 @@ fn probeProviderViaComponentHealth(
     model: []const u8,
 ) ProviderProbeResult {
     const args: []const []const u8 = if (model.len > 0)
-        &.{ "--probe-provider-health", "--provider", provider, "--model", model, "--timeout-secs", "10" }
+        &.{ "--probe-provider-health", "--provider", provider, "--model", model, "--timeout-secs", "30" }
     else
-        &.{ "--probe-provider-health", "--provider", provider, "--timeout-secs", "10" };
+        &.{ "--probe-provider-health", "--provider", provider, "--timeout-secs", "30" };
     const result = component_cli.runWithComponentHome(
         allocator,
         component,

--- a/src/api/providers.zig
+++ b/src/api/providers.zig
@@ -152,6 +152,10 @@ pub fn handleCreate(
         try state.save();
     }
 
+    // Sync credentials to all live nullclaw instances
+    const sp_for_sync = state.getSavedProvider(new_id).?;
+    syncProviderToInstances(allocator, state, paths, sp_for_sync.provider, sp_for_sync.api_key, sp_for_sync.base_url);
+
     // Return the saved provider
     const sp = state.getSavedProvider(new_id).?;
     var buf = std.array_list.Managed(u8).init(allocator);
@@ -258,6 +262,8 @@ pub fn handleUpdate(
     try state.save();
 
     const sp = state.getSavedProvider(id).?;
+    syncProviderToInstances(allocator, state, paths, sp.provider, sp.api_key, sp.base_url);
+
     var buf = std.array_list.Managed(u8).init(allocator);
     errdefer buf.deinit();
     try appendProviderJson(&buf, sp, true);
@@ -480,6 +486,101 @@ pub fn handleProbeModels(allocator: std.mem.Allocator, target: []const u8) ![]co
     return buf.toOwnedSlice();
 }
 
+// ─── Instance Config Sync ────────────────────────────────────────────────────
+
+/// Sync provider credentials (api_key + base_url) into every registered
+/// nullclaw instance's config.json.  Best-effort: per-instance errors are
+/// silently swallowed so a corrupt config on one instance doesn't block others.
+fn syncProviderToInstances(
+    allocator: std.mem.Allocator,
+    state: *state_mod.State,
+    paths: paths_mod.Paths,
+    provider: []const u8,
+    api_key: []const u8,
+    base_url: []const u8,
+) void {
+    const names = state.instanceNames("nullclaw") catch return;
+    defer if (names) |list| allocator.free(list);
+    const list = names orelse return;
+    for (list) |name| {
+        syncProviderToInstance(allocator, paths, name, provider, api_key, base_url) catch {};
+    }
+}
+
+fn syncProviderToInstance(
+    allocator: std.mem.Allocator,
+    paths: paths_mod.Paths,
+    instance_name: []const u8,
+    provider: []const u8,
+    api_key: []const u8,
+    base_url: []const u8,
+) !void {
+    const config_path = try paths.instanceConfig(allocator, "nullclaw", instance_name);
+    defer allocator.free(config_path);
+
+    // Read existing config or fall back to empty object if the file is missing.
+    const contents = blk: {
+        const file = std_compat.fs.openFileAbsolute(config_path, .{}) catch |err| switch (err) {
+            error.FileNotFound => break :blk try allocator.dupe(u8, "{}"),
+            else => return err,
+        };
+        defer file.close();
+        break :blk try file.readToEndAlloc(allocator, 8 * 1024 * 1024);
+    };
+    defer allocator.free(contents);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, contents, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    });
+    defer parsed.deinit();
+    const ja = parsed.arena.allocator();
+
+    if (parsed.value != .object) return error.InvalidConfig;
+    const root = &parsed.value.object;
+
+    // Navigate/create: root → models → providers → <provider>
+    const models_obj = try ensureObjectInMap(ja, root, "models");
+    const providers_obj = try ensureObjectInMap(ja, models_obj, "providers");
+    const provider_obj = try ensureObjectInMap(ja, providers_obj, provider);
+
+    // Set api_key (string bytes are state-owned, outlive the arena)
+    try provider_obj.put(ja, "api_key", .{ .string = api_key });
+
+    // Set base_url only when present (mirrors writeMinimalProviderConfig behaviour)
+    if (base_url.len > 0) {
+        try provider_obj.put(ja, "base_url", .{ .string = base_url });
+    }
+
+    // Serialize and write back
+    const rendered = try std.json.Stringify.valueAlloc(allocator, parsed.value, .{
+        .whitespace = .indent_2,
+        .emit_null_optional_fields = false,
+    });
+    defer allocator.free(rendered);
+
+    const out = try std_compat.fs.createFileAbsolute(config_path, .{ .truncate = true });
+    defer out.close();
+    try out.writeAll(rendered);
+    try out.writeAll("\n");
+}
+
+fn ensureObjectInMap(
+    allocator: std.mem.Allocator,
+    obj: *std.json.ObjectMap,
+    key: []const u8,
+) !*std.json.ObjectMap {
+    const gop = try obj.getOrPut(allocator, key);
+    if (!gop.found_existing) {
+        gop.value_ptr.* = .{ .object = .empty };
+        return &gop.value_ptr.object;
+    }
+    if (gop.value_ptr.* != .object) {
+        gop.value_ptr.* = .{ .object = .empty };
+    }
+    return &gop.value_ptr.object;
+}
+
 fn findProviderProbeComponent(allocator: std.mem.Allocator, state: *state_mod.State) ?[]const u8 {
     const names = state.instanceNames("nullclaw") catch return null;
     defer if (names) |list| allocator.free(list);
@@ -668,16 +769,16 @@ test "handleList includes base_url for openai-compatible provider" {
     defer s.deinit();
 
     try s.addSavedProvider(.{
-        .provider = "infini-ai",
-        .api_key = "sk-cp-test",
-        .model = "minimax-m2.7",
-        .base_url = "https://cloud.infini-ai.com/maas/coding/v1",
+        .provider = "custom-llm",
+        .api_key = "sk-test-key",
+        .model = "test-model",
+        .base_url = "https://example.com/v1",
     });
 
     const json = try handleList(allocator, &s, true);
     defer allocator.free(json);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"base_url\":\"https://cloud.infini-ai.com/maas/coding/v1\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"provider\":\"infini-ai\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"base_url\":\"https://example.com/v1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"provider\":\"custom-llm\"") != null);
 }
 
 test "handleList includes empty base_url for standard provider" {
@@ -797,13 +898,13 @@ test "handleCreate with base_url saves without requiring nullclaw probe" {
     const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
 
     const body =
-        \\{"provider":"local-llm","api_key":"sk-test","model":"llama3","base_url":"http://127.0.0.1:5801/v1"}
+        \\{"provider":"local-llm","api_key":"sk-test","model":"llama3","base_url":"http://127.0.0.1:19999/v1"}
     ;
     const json = try handleCreate(allocator, body, &s, paths);
     defer allocator.free(json);
 
     try std.testing.expect(std.mem.indexOf(u8, json, "\"error\"") == null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"base_url\":\"http://127.0.0.1:5801/v1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"base_url\":\"http://127.0.0.1:19999/v1\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"provider\":\"local-llm\"") != null);
     try std.testing.expectEqual(@as(usize, 1), s.savedProviders().len);
 }
@@ -839,7 +940,7 @@ test "handleCreate without base_url requires nullclaw instance" {
 test "handleValidate for custom provider uses models probe (not nullclaw)" {
     // Regression: handleValidate for a custom provider must not require a nullclaw
     // instance — it uses the /models probe directly. The probe will fail here
-    // (no server at 5801) but the key point is we get a live_ok + reason response,
+    // (no server at 19999) but the key point is we get a live_ok + reason response,
     // NOT the old "custom endpoint — validation via /models not yet available" placeholder.
     const allocator = std.testing.allocator;
     const tmp = "/tmp/nullhub-provider-test-validate-custom";
@@ -856,7 +957,7 @@ test "handleValidate for custom provider uses models probe (not nullclaw)" {
     try s.addSavedProvider(.{
         .provider = "local-llm",
         .api_key = "sk-test",
-        .base_url = "http://127.0.0.1:5801/v1",
+        .base_url = "http://127.0.0.1:19999/v1",
     });
 
     const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
@@ -868,7 +969,7 @@ test "handleValidate for custom provider uses models probe (not nullclaw)" {
     try std.testing.expect(std.mem.indexOf(u8, json, "not yet available") == null);
     // No nullclaw probe: no "Install a nullclaw instance" error expected.
     try std.testing.expect(std.mem.indexOf(u8, json, "Install a nullclaw instance") == null);
-    // Probe should fail (5801 is not running in tests)
+    // Probe should fail (19999 is not running in tests)
     try std.testing.expect(std.mem.indexOf(u8, json, "\"live_ok\":false") != null);
 }
 
@@ -926,7 +1027,7 @@ test "handleProbeModels returns error when base_url missing" {
 
 test "handleProbeModels returns error when api_key missing" {
     const allocator = std.testing.allocator;
-    const json = try handleProbeModels(allocator, "/api/providers/probe-models?base_url=http%3A%2F%2F127.0.0.1%3A5801%2Fv1");
+    const json = try handleProbeModels(allocator, "/api/providers/probe-models?base_url=http%3A%2F%2F127.0.0.1%3A19999%2Fv1");
     defer allocator.free(json);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"error\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "api_key") != null);
@@ -973,4 +1074,111 @@ test "handleCreate custom provider records last_validation_at after probe attemp
     try std.testing.expect(sp.last_validation_at.len > 0);
     // last_validation_ok must be false (port 19998 not running)
     try std.testing.expect(!sp.last_validation_ok);
+}
+
+// ─── syncProviderToInstances tests ───────────────────────────────────────────
+
+fn makeInstanceDir(tmp: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const instances = try std.fmt.bufPrint(&buf, "{s}/instances", .{tmp});
+    std_compat.fs.makeDirAbsolute(instances) catch |e| if (e != error.PathAlreadyExists) return e;
+    const nullclaw = try std.fmt.bufPrint(&buf, "{s}/instances/nullclaw", .{tmp});
+    std_compat.fs.makeDirAbsolute(nullclaw) catch |e| if (e != error.PathAlreadyExists) return e;
+    const default = try std.fmt.bufPrint(&buf, "{s}/instances/nullclaw/default", .{tmp});
+    std_compat.fs.makeDirAbsolute(default) catch |e| if (e != error.PathAlreadyExists) return e;
+}
+
+test "syncProviderToInstances writes provider creds into instance config" {
+    const allocator = std.testing.allocator;
+    const tmp = "/tmp/nullhub-sync-test-write";
+    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+    std_compat.fs.makeDirAbsolute(tmp) catch {};
+    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+
+    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
+    defer s.deinit();
+    try s.addInstance("nullclaw", "default", .{ .version = "v2026.1.0" });
+
+    try makeInstanceDir(tmp);
+
+    // Write an existing config with an unrelated key
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/instances/nullclaw/default/config.json", .{tmp});
+    defer allocator.free(config_path);
+    {
+        const f = try std_compat.fs.createFileAbsolute(config_path, .{});
+        defer f.close();
+        try f.writeAll("{\"port\":9100}\n");
+    }
+
+    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
+    syncProviderToInstances(allocator, &s, paths, "custom-llm", "sk-abc123", "https://example.com/v1");
+
+    // Read back and verify credentials are present
+    const f2 = try std_compat.fs.openFileAbsolute(config_path, .{});
+    defer f2.close();
+    const result = try f2.readToEndAlloc(allocator, 64 * 1024);
+    defer allocator.free(result);
+
+    try std.testing.expect(std.mem.indexOf(u8, result, "\"custom-llm\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "\"sk-abc123\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "\"https://example.com/v1\"") != null);
+    // Existing key must not be clobbered
+    try std.testing.expect(std.mem.indexOf(u8, result, "\"port\"") != null);
+}
+
+test "syncProviderToInstances omits base_url when empty" {
+    const allocator = std.testing.allocator;
+    const tmp = "/tmp/nullhub-sync-test-no-baseurl";
+    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+    std_compat.fs.makeDirAbsolute(tmp) catch {};
+    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+
+    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
+    defer s.deinit();
+    try s.addInstance("nullclaw", "default", .{ .version = "v2026.1.0" });
+
+    try makeInstanceDir(tmp);
+
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/instances/nullclaw/default/config.json", .{tmp});
+    defer allocator.free(config_path);
+    {
+        const f = try std_compat.fs.createFileAbsolute(config_path, .{});
+        defer f.close();
+        try f.writeAll("{}\n");
+    }
+
+    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
+    syncProviderToInstances(allocator, &s, paths, "openrouter", "sk-or-key", "");
+
+    const f2 = try std_compat.fs.openFileAbsolute(config_path, .{});
+    defer f2.close();
+    const result = try f2.readToEndAlloc(allocator, 64 * 1024);
+    defer allocator.free(result);
+
+    try std.testing.expect(std.mem.indexOf(u8, result, "\"openrouter\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "\"sk-or-key\"") != null);
+    // base_url must not appear when empty
+    try std.testing.expect(std.mem.indexOf(u8, result, "\"base_url\"") == null);
+}
+
+test "syncProviderToInstances is no-op when no nullclaw instances" {
+    const allocator = std.testing.allocator;
+    const tmp = "/tmp/nullhub-sync-test-noop";
+    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+    std_compat.fs.makeDirAbsolute(tmp) catch {};
+    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+
+    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
+    defer s.deinit();
+    // No nullclaw instances registered
+
+    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
+    // Should not panic or error when there are no instances
+    syncProviderToInstances(allocator, &s, paths, "openrouter", "sk-key", "");
 }

--- a/src/api/providers.zig
+++ b/src/api/providers.zig
@@ -4,6 +4,7 @@ const state_mod = @import("../core/state.zig");
 const paths_mod = @import("../core/paths.zig");
 const helpers = @import("helpers.zig");
 const wizard_api = @import("wizard.zig");
+const query_mod = @import("query.zig");
 
 const appendEscaped = helpers.appendEscaped;
 
@@ -39,6 +40,12 @@ pub fn isValidatePath(target: []const u8) bool {
 pub fn hasRevealParam(target: []const u8) bool {
     const query_start = std.mem.indexOfScalar(u8, target, '?') orelse return false;
     return std.mem.indexOf(u8, target[query_start..], "reveal=true") != null;
+}
+
+/// Check if path matches /api/providers/probe-models
+pub fn isProbeModelsPath(target: []const u8) bool {
+    return std.mem.eql(u8, target, "/api/providers/probe-models") or
+        std.mem.startsWith(u8, target, "/api/providers/probe-models?");
 }
 
 // ─── Handlers ────────────────────────────────────────────────────────────────
@@ -109,6 +116,14 @@ pub fn handleCreate(
         }
         validated_ok = true;
         validated_with_buf = try allocator.dupe(u8, component_name);
+    } else {
+        // Custom provider: probe the /models endpoint; always save regardless of result.
+        var models_probe = probeModels(allocator, parsed.value.base_url, parsed.value.api_key);
+        defer models_probe.deinit(allocator);
+        validated_ok = models_probe.live_ok;
+        if (validated_ok) {
+            validated_with_buf = try allocator.dupe(u8, "models-probe");
+        }
     }
 
     const validated_with = validated_with_buf orelse "";
@@ -121,16 +136,23 @@ pub fn handleCreate(
         .validated_with = validated_with,
     });
 
-    // Record validation attempt if we validated
+    // Record validation result
+    const providers_list = state.savedProviders();
+    const new_id = providers_list[providers_list.len - 1].id;
     if (validated_ok) {
-        const providers = state.savedProviders();
-        const new_id = providers[providers.len - 1].id;
         try persistValidationAttempt(allocator, state, new_id, validated_with, true);
+    } else if (is_custom) {
+        // Custom probe ran but failed — record the attempt so the UI shows status
+        const now = try nowIso8601(allocator);
+        defer allocator.free(now);
+        _ = try state.updateSavedProvider(new_id, .{
+            .last_validation_at = now,
+            .last_validation_ok = false,
+        });
+        try state.save();
     }
 
     // Return the saved provider
-    const providers = state.savedProviders();
-    const new_id = providers[providers.len - 1].id;
     const sp = state.getSavedProvider(new_id).?;
     var buf = std.array_list.Managed(u8).init(allocator);
     errdefer buf.deinit();
@@ -212,12 +234,20 @@ pub fn handleUpdate(
                 .last_validation_ok = true,
             });
         } else {
-            // Custom provider: update fields directly without probe
+            // Custom provider: probe /models endpoint; always update regardless of result.
+            var models_probe = probeModels(allocator, effective_base_url, effective_key);
+            defer models_probe.deinit(allocator);
+            const now = try nowIso8601(allocator);
+            defer allocator.free(now);
             _ = try state.updateSavedProvider(id, .{
                 .name = parsed.value.name,
                 .api_key = parsed.value.api_key,
                 .model = parsed.value.model,
                 .base_url = parsed.value.base_url,
+                .validated_at = if (models_probe.live_ok) now else null,
+                .validated_with = if (models_probe.live_ok) "models-probe" else null,
+                .last_validation_at = now,
+                .last_validation_ok = models_probe.live_ok,
             });
         }
     } else {
@@ -252,11 +282,21 @@ pub fn handleValidate(
 ) ![]const u8 {
     const existing = state.getSavedProvider(id) orelse return try allocator.dupe(u8, "{\"error\":\"provider not found\"}");
 
-    // Custom providers are validated via the /models endpoint (not yet implemented).
-    // Return a clear response rather than running the nullclaw probe against an
-    // arbitrary endpoint that the probe was not designed for.
+    // Custom providers: validate via the /models endpoint instead of nullclaw probe.
     if (existing.base_url.len > 0) {
-        return try allocator.dupe(u8, "{\"live_ok\":false,\"reason\":\"custom endpoint — validation via /models not yet available\"}");
+        var models_probe = probeModels(allocator, existing.base_url, existing.api_key);
+        defer models_probe.deinit(allocator);
+
+        try persistValidationAttempt(allocator, state, id, "models-probe", models_probe.live_ok);
+
+        var buf = std.array_list.Managed(u8).init(allocator);
+        errdefer buf.deinit();
+        try buf.appendSlice("{\"live_ok\":");
+        try buf.appendSlice(if (models_probe.live_ok) "true" else "false");
+        try buf.appendSlice(",\"reason\":\"");
+        try appendEscaped(&buf, models_probe.reason);
+        try buf.appendSlice("\"}");
+        return buf.toOwnedSlice();
     }
 
     const component_name = findProviderProbeComponent(allocator, state) orelse
@@ -283,6 +323,162 @@ pub fn handleValidate(
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// ── /models probe ──────────────────────────────────────────────────────────
+
+/// Result of probing an OpenAI-compatible /models endpoint.
+const ModelsProbeResult = struct {
+    live_ok: bool,
+    /// Static string literal — never allocated, never freed.
+    reason: []const u8,
+    /// Owned JSON array string of model IDs, e.g. `["gpt-4","gpt-3.5-turbo"]`.
+    /// Always valid JSON; `"[]"` when the probe failed or returned no data.
+    model_ids_json: []u8,
+
+    fn deinit(self: *ModelsProbeResult, allocator: std.mem.Allocator) void {
+        allocator.free(self.model_ids_json);
+    }
+};
+
+/// Build the models URL from a base_url (appends `/models`).
+fn buildModelsUrl(allocator: std.mem.Allocator, base_url: []const u8) ![]const u8 {
+    if (std.mem.endsWith(u8, base_url, "/")) {
+        return std.fmt.allocPrint(allocator, "{s}models", .{base_url});
+    }
+    return std.fmt.allocPrint(allocator, "{s}/models", .{base_url});
+}
+
+/// Parse `data[].id` strings from an OpenAI-compatible /models JSON response.
+/// Returns a JSON array string like `["gpt-4","llama3"]`. Caller owns the result.
+fn parseModelIdsJson(allocator: std.mem.Allocator, body: []const u8) []u8 {
+    const empty = allocator.dupe(u8, "[]") catch return @constCast("[]");
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, body, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    }) catch return empty;
+    defer parsed.deinit();
+
+    const data = switch (parsed.value) {
+        .object => |obj| obj.get("data") orelse return empty,
+        else => return empty,
+    };
+    const items = switch (data) {
+        .array => |arr| arr.items,
+        else => return empty,
+    };
+
+    var out = std.array_list.Managed(u8).init(allocator);
+    out.append('[') catch return empty;
+    var first = true;
+    for (items) |item| {
+        const id_val = switch (item) {
+            .object => |obj| obj.get("id") orelse continue,
+            else => continue,
+        };
+        const id_str = switch (id_val) {
+            .string => |s| s,
+            else => continue,
+        };
+        if (!first) out.append(',') catch break;
+        first = false;
+        out.append('"') catch break;
+        appendEscaped(&out, id_str) catch break;
+        out.append('"') catch break;
+    }
+    out.append(']') catch return empty;
+    allocator.free(empty);
+    return out.toOwnedSlice() catch @constCast("[]");
+}
+
+/// Probe an OpenAI-compatible `/models` endpoint using the given key.
+fn probeModels(
+    allocator: std.mem.Allocator,
+    base_url: []const u8,
+    api_key: []const u8,
+) ModelsProbeResult {
+    const empty_models = allocator.dupe(u8, "[]") catch return .{
+        .live_ok = false,
+        .reason = "alloc_failed",
+        .model_ids_json = @constCast("[]"),
+    };
+
+    const url = buildModelsUrl(allocator, base_url) catch return .{
+        .live_ok = false,
+        .reason = "url_build_failed",
+        .model_ids_json = empty_models,
+    };
+    defer allocator.free(url);
+
+    var client: std.http.Client = .{ .allocator = allocator, .io = std_compat.io() };
+    defer client.deinit();
+
+    var response_body: std.Io.Writer.Allocating = .init(allocator);
+    defer response_body.deinit();
+
+    const auth_header_value = std.fmt.allocPrint(allocator, "Bearer {s}", .{api_key}) catch
+        return .{ .live_ok = false, .reason = "alloc_failed", .model_ids_json = empty_models };
+    defer allocator.free(auth_header_value);
+
+    const header_buf = [1]std.http.Header{
+        .{ .name = "Authorization", .value = auth_header_value },
+    };
+
+    const result = client.fetch(.{
+        .location = .{ .url = url },
+        .method = .GET,
+        .response_writer = &response_body.writer,
+        .extra_headers = header_buf[0..],
+    }) catch return .{ .live_ok = false, .reason = "network_error", .model_ids_json = empty_models };
+
+    const status_code = @intFromEnum(result.status);
+    if (status_code == 401 or status_code == 403) {
+        return .{ .live_ok = false, .reason = "auth_failed", .model_ids_json = empty_models };
+    }
+    if (status_code < 200 or status_code >= 300) {
+        return .{ .live_ok = false, .reason = "http_error", .model_ids_json = empty_models };
+    }
+
+    allocator.free(empty_models);
+    const bytes = response_body.toOwnedSlice() catch return .{
+        .live_ok = true,
+        .reason = "",
+        .model_ids_json = allocator.dupe(u8, "[]") catch @constCast("[]"),
+    };
+    defer allocator.free(bytes);
+
+    return .{
+        .live_ok = true,
+        .reason = "",
+        .model_ids_json = parseModelIdsJson(allocator, bytes),
+    };
+}
+
+/// GET /api/providers/probe-models?base_url=...&api_key=...
+/// Probes an OpenAI-compatible endpoint's /models endpoint and returns the
+/// list of available model IDs. Used by the frontend before saving a provider.
+pub fn handleProbeModels(allocator: std.mem.Allocator, target: []const u8) ![]const u8 {
+    const base_url = (try query_mod.valueAlloc(allocator, target, "base_url")) orelse
+        return try allocator.dupe(u8, "{\"error\":\"base_url is required\"}");
+    defer allocator.free(base_url);
+
+    const api_key = (try query_mod.valueAlloc(allocator, target, "api_key")) orelse
+        return try allocator.dupe(u8, "{\"error\":\"api_key is required\"}");
+    defer allocator.free(api_key);
+
+    var probe = probeModels(allocator, base_url, api_key);
+    defer probe.deinit(allocator);
+
+    var buf = std.array_list.Managed(u8).init(allocator);
+    errdefer buf.deinit();
+    try buf.appendSlice("{\"live_ok\":");
+    try buf.appendSlice(if (probe.live_ok) "true" else "false");
+    try buf.appendSlice(",\"reason\":\"");
+    try appendEscaped(&buf, probe.reason);
+    try buf.appendSlice("\",\"models\":");
+    try buf.appendSlice(probe.model_ids_json);
+    try buf.append('}');
+    return buf.toOwnedSlice();
+}
 
 fn findProviderProbeComponent(allocator: std.mem.Allocator, state: *state_mod.State) ?[]const u8 {
     const names = state.instanceNames("nullclaw") catch return null;
@@ -640,7 +836,11 @@ test "handleCreate without base_url requires nullclaw instance" {
     try std.testing.expectEqual(@as(usize, 0), s.savedProviders().len);
 }
 
-test "handleValidate for custom provider returns probe-not-applicable message" {
+test "handleValidate for custom provider uses models probe (not nullclaw)" {
+    // Regression: handleValidate for a custom provider must not require a nullclaw
+    // instance — it uses the /models probe directly. The probe will fail here
+    // (no server at 5801) but the key point is we get a live_ok + reason response,
+    // NOT the old "custom endpoint — validation via /models not yet available" placeholder.
     const allocator = std.testing.allocator;
     const tmp = "/tmp/nullhub-provider-test-validate-custom";
     std_compat.fs.deleteTreeAbsolute(tmp) catch {};
@@ -663,6 +863,114 @@ test "handleValidate for custom provider returns probe-not-applicable message" {
     const json = try handleValidate(allocator, 1, &s, paths);
     defer allocator.free(json);
 
+    // Must return a probe result (live_ok present), never the old placeholder string.
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"live_ok\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "not yet available") == null);
+    // No nullclaw probe: no "Install a nullclaw instance" error expected.
+    try std.testing.expect(std.mem.indexOf(u8, json, "Install a nullclaw instance") == null);
+    // Probe should fail (5801 is not running in tests)
     try std.testing.expect(std.mem.indexOf(u8, json, "\"live_ok\":false") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "custom endpoint") != null);
+}
+
+test "buildModelsUrl appends /models with and without trailing slash" {
+    const allocator = std.testing.allocator;
+
+    const a = try buildModelsUrl(allocator, "https://api.example.com/v1");
+    defer allocator.free(a);
+    try std.testing.expectEqualStrings("https://api.example.com/v1/models", a);
+
+    const b = try buildModelsUrl(allocator, "https://api.example.com/v1/");
+    defer allocator.free(b);
+    try std.testing.expectEqualStrings("https://api.example.com/v1/models", b);
+}
+
+test "parseModelIdsJson extracts data[].id strings" {
+    const allocator = std.testing.allocator;
+    const body =
+        \\{"object":"list","data":[{"id":"gpt-4","object":"model"},{"id":"gpt-3.5-turbo","object":"model"}]}
+    ;
+    const result = parseModelIdsJson(allocator, body);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("[\"gpt-4\",\"gpt-3.5-turbo\"]", result);
+}
+
+test "parseModelIdsJson returns empty array for invalid JSON" {
+    const allocator = std.testing.allocator;
+    const result = parseModelIdsJson(allocator, "not json");
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("[]", result);
+}
+
+test "parseModelIdsJson returns empty array for missing data field" {
+    const allocator = std.testing.allocator;
+    const result = parseModelIdsJson(allocator, "{\"object\":\"list\"}");
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("[]", result);
+}
+
+test "isProbeModelsPath matches correct paths" {
+    try std.testing.expect(isProbeModelsPath("/api/providers/probe-models"));
+    try std.testing.expect(isProbeModelsPath("/api/providers/probe-models?base_url=x&api_key=y"));
+    try std.testing.expect(!isProbeModelsPath("/api/providers/1"));
+    try std.testing.expect(!isProbeModelsPath("/api/providers"));
+    try std.testing.expect(!isProbeModelsPath("/api/providers/probe-modelsX"));
+}
+
+test "handleProbeModels returns error when base_url missing" {
+    const allocator = std.testing.allocator;
+    const json = try handleProbeModels(allocator, "/api/providers/probe-models?api_key=sk-test");
+    defer allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"error\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "base_url") != null);
+}
+
+test "handleProbeModels returns error when api_key missing" {
+    const allocator = std.testing.allocator;
+    const json = try handleProbeModels(allocator, "/api/providers/probe-models?base_url=http%3A%2F%2F127.0.0.1%3A5801%2Fv1");
+    defer allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"error\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "api_key") != null);
+}
+
+test "handleProbeModels returns live_ok false for unreachable endpoint" {
+    const allocator = std.testing.allocator;
+    // Port 19999 should not be running anything in CI
+    const json = try handleProbeModels(allocator, "/api/providers/probe-models?base_url=http%3A%2F%2F127.0.0.1%3A19999%2Fv1&api_key=sk-test");
+    defer allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"live_ok\":false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"models\":[]") != null);
+}
+
+test "handleCreate custom provider records last_validation_at after probe attempt" {
+    // When a custom provider is created, a /models probe is attempted. Even if it
+    // fails (no server), last_validation_at must be set in the saved state.
+    const allocator = std.testing.allocator;
+    const tmp = "/tmp/nullhub-provider-test-custom-create-ts";
+    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+    std_compat.fs.makeDirAbsolute(tmp) catch {};
+    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+
+    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    defer allocator.free(state_path);
+
+    var s = state_mod.State.init(allocator, state_path);
+    defer s.deinit();
+
+    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
+
+    const body =
+        \\{"provider":"local-llm","api_key":"sk-test","model":"llama3","base_url":"http://127.0.0.1:19998/v1"}
+    ;
+    const json = try handleCreate(allocator, body, &s, paths);
+    defer allocator.free(json);
+
+    // Must save successfully (no error)
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"error\"") == null);
+    try std.testing.expectEqual(@as(usize, 1), s.savedProviders().len);
+
+    // last_validation_at must be set (probe was attempted)
+    const sp = s.savedProviders()[0];
+    try std.testing.expect(sp.last_validation_at.len > 0);
+    // last_validation_ok must be false (port 19998 not running)
+    try std.testing.expect(!sp.last_validation_ok);
 }

--- a/src/api/providers.zig
+++ b/src/api/providers.zig
@@ -85,10 +85,8 @@ pub fn handleCreate(
     }) catch return try allocator.dupe(u8, "{\"error\":\"invalid JSON body\"}");
     defer parsed.deinit();
 
-    // Custom providers (base_url set) bypass the nullclaw probe: the probe is
-    // designed for known providers and can misclassify valid responses from
-    // arbitrary OpenAI-compatible endpoints. Credential validation for custom
-    // endpoints will be handled via the /models probe (added in a follow-up).
+    // Custom providers (base_url set) use the OpenAI-compatible /models probe:
+    // the nullclaw probe only understands known provider names.
     const is_custom = parsed.value.base_url.len > 0;
     var validated_ok = false;
     var validated_with_buf: ?[]const u8 = null;
@@ -342,7 +340,7 @@ const ModelsProbeResult = struct {
     model_ids_json: []u8,
 
     fn deinit(self: *ModelsProbeResult, allocator: std.mem.Allocator) void {
-        allocator.free(self.model_ids_json);
+        if (self.model_ids_json.len > 0) allocator.free(self.model_ids_json);
     }
 };
 
@@ -354,27 +352,31 @@ fn buildModelsUrl(allocator: std.mem.Allocator, base_url: []const u8) ![]const u
     return std.fmt.allocPrint(allocator, "{s}/models", .{base_url});
 }
 
+fn emptyModelIdsJson(allocator: std.mem.Allocator) ![]u8 {
+    return allocator.dupe(u8, "[]");
+}
+
 /// Parse `data[].id` strings from an OpenAI-compatible /models JSON response.
 /// Returns a JSON array string like `["gpt-4","llama3"]`. Caller owns the result.
-fn parseModelIdsJson(allocator: std.mem.Allocator, body: []const u8) []u8 {
-    const empty = allocator.dupe(u8, "[]") catch return @constCast("[]");
+fn parseModelIdsJson(allocator: std.mem.Allocator, body: []const u8) ![]u8 {
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, body, .{
         .allocate = .alloc_always,
         .ignore_unknown_fields = true,
-    }) catch return empty;
+    }) catch return emptyModelIdsJson(allocator);
     defer parsed.deinit();
 
     const data = switch (parsed.value) {
-        .object => |obj| obj.get("data") orelse return empty,
-        else => return empty,
+        .object => |obj| obj.get("data") orelse return emptyModelIdsJson(allocator),
+        else => return emptyModelIdsJson(allocator),
     };
     const items = switch (data) {
         .array => |arr| arr.items,
-        else => return empty,
+        else => return emptyModelIdsJson(allocator),
     };
 
     var out = std.array_list.Managed(u8).init(allocator);
-    out.append('[') catch return empty;
+    errdefer out.deinit();
+    try out.append('[');
     var first = true;
     for (items) |item| {
         const id_val = switch (item) {
@@ -385,15 +387,14 @@ fn parseModelIdsJson(allocator: std.mem.Allocator, body: []const u8) []u8 {
             .string => |s| s,
             else => continue,
         };
-        if (!first) out.append(',') catch break;
+        if (!first) try out.append(',');
         first = false;
-        out.append('"') catch break;
-        appendEscaped(&out, id_str) catch break;
-        out.append('"') catch break;
+        try out.append('"');
+        try appendEscaped(&out, id_str);
+        try out.append('"');
     }
-    out.append(']') catch return empty;
-    allocator.free(empty);
-    return out.toOwnedSlice() catch @constCast("[]");
+    try out.append(']');
+    return out.toOwnedSlice();
 }
 
 /// Probe an OpenAI-compatible `/models` endpoint using the given key.
@@ -402,10 +403,10 @@ fn probeModels(
     base_url: []const u8,
     api_key: []const u8,
 ) ModelsProbeResult {
-    const empty_models = allocator.dupe(u8, "[]") catch return .{
+    const empty_models = emptyModelIdsJson(allocator) catch return .{
         .live_ok = false,
         .reason = "alloc_failed",
-        .model_ids_json = @constCast("[]"),
+        .model_ids_json = &.{},
     };
 
     const url = buildModelsUrl(allocator, base_url) catch return .{
@@ -421,19 +422,22 @@ fn probeModels(
     var response_body: std.Io.Writer.Allocating = .init(allocator);
     defer response_body.deinit();
 
-    const auth_header_value = std.fmt.allocPrint(allocator, "Bearer {s}", .{api_key}) catch
-        return .{ .live_ok = false, .reason = "alloc_failed", .model_ids_json = empty_models };
-    defer allocator.free(auth_header_value);
-
-    const header_buf = [1]std.http.Header{
-        .{ .name = "Authorization", .value = auth_header_value },
-    };
+    var auth_header_value: ?[]u8 = null;
+    defer if (auth_header_value) |value| allocator.free(value);
+    var header_buf: [1]std.http.Header = undefined;
+    const extra_headers: []const std.http.Header = if (api_key.len > 0) blk: {
+        const value = std.fmt.allocPrint(allocator, "Bearer {s}", .{api_key}) catch
+            return .{ .live_ok = false, .reason = "alloc_failed", .model_ids_json = empty_models };
+        auth_header_value = value;
+        header_buf[0] = .{ .name = "Authorization", .value = value };
+        break :blk header_buf[0..];
+    } else &.{};
 
     const result = client.fetch(.{
         .location = .{ .url = url },
         .method = .GET,
         .response_writer = &response_body.writer,
-        .extra_headers = header_buf[0..],
+        .extra_headers = extra_headers,
     }) catch return .{ .live_ok = false, .reason = "network_error", .model_ids_json = empty_models };
 
     const status_code = @intFromEnum(result.status);
@@ -444,19 +448,49 @@ fn probeModels(
         return .{ .live_ok = false, .reason = "http_error", .model_ids_json = empty_models };
     }
 
-    allocator.free(empty_models);
     const bytes = response_body.toOwnedSlice() catch return .{
         .live_ok = true,
         .reason = "",
-        .model_ids_json = allocator.dupe(u8, "[]") catch @constCast("[]"),
+        .model_ids_json = empty_models,
     };
     defer allocator.free(bytes);
+
+    const model_ids_json = parseModelIdsJson(allocator, bytes) catch return .{
+        .live_ok = true,
+        .reason = "",
+        .model_ids_json = empty_models,
+    };
+    allocator.free(empty_models);
 
     return .{
         .live_ok = true,
         .reason = "",
-        .model_ids_json = parseModelIdsJson(allocator, bytes),
+        .model_ids_json = model_ids_json,
     };
+}
+
+fn handleProbeModelsFromValues(
+    allocator: std.mem.Allocator,
+    base_url: []const u8,
+    api_key: []const u8,
+) ![]const u8 {
+    var probe = probeModels(allocator, base_url, api_key);
+    defer probe.deinit(allocator);
+
+    var buf = std.array_list.Managed(u8).init(allocator);
+    errdefer buf.deinit();
+    try buf.appendSlice("{\"live_ok\":");
+    try buf.appendSlice(if (probe.live_ok) "true" else "false");
+    try buf.appendSlice(",\"reason\":\"");
+    try appendEscaped(&buf, probe.reason);
+    try buf.appendSlice("\",\"models\":");
+    if (probe.model_ids_json.len > 0) {
+        try buf.appendSlice(probe.model_ids_json);
+    } else {
+        try buf.appendSlice("[]");
+    }
+    try buf.append('}');
+    return buf.toOwnedSlice();
 }
 
 /// GET /api/providers/probe-models?base_url=...&api_key=...
@@ -468,22 +502,29 @@ pub fn handleProbeModels(allocator: std.mem.Allocator, target: []const u8) ![]co
     defer allocator.free(base_url);
 
     const api_key = (try query_mod.valueAlloc(allocator, target, "api_key")) orelse
-        return try allocator.dupe(u8, "{\"error\":\"api_key is required\"}");
+        try allocator.dupe(u8, "");
     defer allocator.free(api_key);
 
-    var probe = probeModels(allocator, base_url, api_key);
-    defer probe.deinit(allocator);
+    return handleProbeModelsFromValues(allocator, base_url, api_key);
+}
 
-    var buf = std.array_list.Managed(u8).init(allocator);
-    errdefer buf.deinit();
-    try buf.appendSlice("{\"live_ok\":");
-    try buf.appendSlice(if (probe.live_ok) "true" else "false");
-    try buf.appendSlice(",\"reason\":\"");
-    try appendEscaped(&buf, probe.reason);
-    try buf.appendSlice("\",\"models\":");
-    try buf.appendSlice(probe.model_ids_json);
-    try buf.append('}');
-    return buf.toOwnedSlice();
+/// POST /api/providers/probe-models
+/// Body: {"base_url":"...","api_key":"..."}; api_key may be empty for local endpoints.
+pub fn handleProbeModelsBody(allocator: std.mem.Allocator, body: []const u8) ![]const u8 {
+    const parsed = std.json.parseFromSlice(struct {
+        base_url: []const u8,
+        api_key: []const u8 = "",
+    }, allocator, body, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    }) catch return try allocator.dupe(u8, "{\"error\":\"invalid JSON body\"}");
+    defer parsed.deinit();
+
+    if (parsed.value.base_url.len == 0) {
+        return try allocator.dupe(u8, "{\"error\":\"base_url is required\"}");
+    }
+
+    return handleProbeModelsFromValues(allocator, parsed.value.base_url, parsed.value.api_key);
 }
 
 // ─── Instance Config Sync ────────────────────────────────────────────────────
@@ -550,6 +591,8 @@ fn syncProviderToInstance(
     // Set base_url only when present (mirrors writeMinimalProviderConfig behaviour)
     if (base_url.len > 0) {
         try provider_obj.put(ja, "base_url", .{ .string = base_url });
+    } else {
+        _ = provider_obj.orderedRemove("base_url");
     }
 
     // Serialize and write back
@@ -990,21 +1033,21 @@ test "parseModelIdsJson extracts data[].id strings" {
     const body =
         \\{"object":"list","data":[{"id":"gpt-4","object":"model"},{"id":"gpt-3.5-turbo","object":"model"}]}
     ;
-    const result = parseModelIdsJson(allocator, body);
+    const result = try parseModelIdsJson(allocator, body);
     defer allocator.free(result);
     try std.testing.expectEqualStrings("[\"gpt-4\",\"gpt-3.5-turbo\"]", result);
 }
 
 test "parseModelIdsJson returns empty array for invalid JSON" {
     const allocator = std.testing.allocator;
-    const result = parseModelIdsJson(allocator, "not json");
+    const result = try parseModelIdsJson(allocator, "not json");
     defer allocator.free(result);
     try std.testing.expectEqualStrings("[]", result);
 }
 
 test "parseModelIdsJson returns empty array for missing data field" {
     const allocator = std.testing.allocator;
-    const result = parseModelIdsJson(allocator, "{\"object\":\"list\"}");
+    const result = try parseModelIdsJson(allocator, "{\"object\":\"list\"}");
     defer allocator.free(result);
     try std.testing.expectEqualStrings("[]", result);
 }
@@ -1025,12 +1068,21 @@ test "handleProbeModels returns error when base_url missing" {
     try std.testing.expect(std.mem.indexOf(u8, json, "base_url") != null);
 }
 
-test "handleProbeModels returns error when api_key missing" {
+test "handleProbeModels allows missing api_key for local endpoints" {
     const allocator = std.testing.allocator;
     const json = try handleProbeModels(allocator, "/api/providers/probe-models?base_url=http%3A%2F%2F127.0.0.1%3A19999%2Fv1");
     defer allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"error\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"live_ok\":false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"models\":[]") != null);
+}
+
+test "handleProbeModelsBody returns error when base_url missing" {
+    const allocator = std.testing.allocator;
+    const json = try handleProbeModelsBody(allocator, "{\"api_key\":\"sk-test\"}");
+    defer allocator.free(json);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"error\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "api_key") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "base_url") != null);
 }
 
 test "handleProbeModels returns live_ok false for unreachable endpoint" {
@@ -1162,6 +1214,42 @@ test "syncProviderToInstances omits base_url when empty" {
     try std.testing.expect(std.mem.indexOf(u8, result, "\"openrouter\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, result, "\"sk-or-key\"") != null);
     // base_url must not appear when empty
+    try std.testing.expect(std.mem.indexOf(u8, result, "\"base_url\"") == null);
+}
+
+test "syncProviderToInstances removes stale base_url when empty" {
+    const allocator = std.testing.allocator;
+    const tmp = "/tmp/nullhub-sync-test-clear-baseurl";
+    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+    std_compat.fs.makeDirAbsolute(tmp) catch {};
+    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+
+    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
+    defer s.deinit();
+    try s.addInstance("nullclaw", "default", .{ .version = "v2026.1.0" });
+
+    try makeInstanceDir(tmp);
+
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/instances/nullclaw/default/config.json", .{tmp});
+    defer allocator.free(config_path);
+    {
+        const f = try std_compat.fs.createFileAbsolute(config_path, .{});
+        defer f.close();
+        try f.writeAll("{\"models\":{\"providers\":{\"openrouter\":{\"api_key\":\"old\",\"base_url\":\"https://old.example.com/v1\"}}}}\n");
+    }
+
+    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
+    syncProviderToInstances(allocator, &s, paths, "openrouter", "sk-or-key", "");
+
+    const f2 = try std_compat.fs.openFileAbsolute(config_path, .{});
+    defer f2.close();
+    const result = try f2.readToEndAlloc(allocator, 64 * 1024);
+    defer allocator.free(result);
+
+    try std.testing.expect(std.mem.indexOf(u8, result, "\"openrouter\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "\"sk-or-key\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, result, "\"base_url\"") == null);
 }
 

--- a/src/api/wizard.zig
+++ b/src/api/wizard.zig
@@ -651,7 +651,7 @@ pub fn handleValidateProviders(
             const now = providers_api.nowIso8601(allocator) catch "";
             defer if (now.len > 0) allocator.free(now);
 
-            if (state.findSavedProviderId(prov.provider, prov.api_key, prov.model)) |existing_id| {
+            if (state.findSavedProviderId(prov.provider, prov.api_key, prov.model, prov.base_url)) |existing_id| {
                 if (now.len > 0) {
                     _ = state.updateSavedProvider(existing_id, .{
                         .validated_at = now,

--- a/src/api/wizard.zig
+++ b/src/api/wizard.zig
@@ -750,9 +750,9 @@ fn probeProviderViaComponentBinary(
     model: []const u8,
 ) ProviderProbeResult {
     const args: []const []const u8 = if (model.len > 0)
-        &.{ "--probe-provider-health", "--provider", provider, "--model", model, "--timeout-secs", "10" }
+        &.{ "--probe-provider-health", "--provider", provider, "--model", model, "--timeout-secs", "30" }
     else
-        &.{ "--probe-provider-health", "--provider", provider, "--timeout-secs", "10" };
+        &.{ "--probe-provider-health", "--provider", provider, "--timeout-secs", "30" };
 
     const result = component_cli.runWithComponentHome(
         allocator,

--- a/src/core/state.zig
+++ b/src/core/state.zig
@@ -323,6 +323,8 @@ pub const State = struct {
             errdefer if (owned_validated_with.len > 0) allocator.free(@constCast(owned_validated_with));
             const owned_last_validation_at = if (sp.last_validation_at.len > 0) try allocator.dupe(u8, sp.last_validation_at) else @as([]const u8, "");
             errdefer if (owned_last_validation_at.len > 0) allocator.free(@constCast(owned_last_validation_at));
+            const owned_base_url = if (sp.base_url.len > 0) try allocator.dupe(u8, sp.base_url) else @as([]const u8, "");
+            errdefer if (owned_base_url.len > 0) allocator.free(@constCast(owned_base_url));
 
             try state.saved_providers.append(.{
                 .id = sp.id,
@@ -330,6 +332,7 @@ pub const State = struct {
                 .provider = owned_provider,
                 .api_key = owned_api_key,
                 .model = owned_model,
+                .base_url = owned_base_url,
                 .validated_at = owned_validated_at,
                 .validated_with = owned_validated_with,
                 .last_validation_at = owned_last_validation_at,
@@ -805,6 +808,7 @@ pub const State = struct {
         for (self.saved_channels.items) |sc| {
             if (std.mem.eql(u8, sc.channel_type, channel_type)) count += 1;
         }
+        if (count == 0) return std.fmt.allocPrint(self.allocator, "{s}", .{label});
         return std.fmt.allocPrint(self.allocator, "{s} #{d}", .{ label, count + 1 });
     }
 
@@ -822,6 +826,10 @@ pub const State = struct {
         for (self.saved_providers.items) |sp| {
             if (std.mem.eql(u8, sp.provider, provider)) count += 1;
         }
+        // Only append a numeric suffix when there is already at least one
+        // provider of this type — avoids the awkward "My Provider #1" for
+        // the common single-instance case.
+        if (count == 0) return std.fmt.allocPrint(self.allocator, "{s}", .{label});
         return std.fmt.allocPrint(self.allocator, "{s} #{d}", .{ label, count + 1 });
     }
 };
@@ -1177,7 +1185,7 @@ test "add saved provider, save, load, verify round-trip" {
         try std.testing.expectEqualStrings("openrouter", providers[0].provider);
         try std.testing.expectEqualStrings("sk-or-xxx", providers[0].api_key);
         try std.testing.expectEqualStrings("anthropic/claude-sonnet-4", providers[0].model);
-        try std.testing.expectEqualStrings("OpenRouter #1", providers[0].name);
+        try std.testing.expectEqualStrings("OpenRouter", providers[0].name);
         try std.testing.expectEqual(@as(u32, 1), providers[0].id);
 
         try s.save();
@@ -1191,7 +1199,7 @@ test "add saved provider, save, load, verify round-trip" {
         try std.testing.expectEqual(@as(usize, 1), providers.len);
         try std.testing.expectEqualStrings("openrouter", providers[0].provider);
         try std.testing.expectEqualStrings("sk-or-xxx", providers[0].api_key);
-        try std.testing.expectEqualStrings("OpenRouter #1", providers[0].name);
+        try std.testing.expectEqualStrings("OpenRouter", providers[0].name);
         try std.testing.expectEqual(@as(u32, 1), providers[0].id);
     }
 }
@@ -1211,9 +1219,9 @@ test "auto-generated name increments per provider type" {
 
     const providers = s.savedProviders();
     try std.testing.expectEqual(@as(usize, 3), providers.len);
-    try std.testing.expectEqualStrings("OpenRouter #1", providers[0].name);
+    try std.testing.expectEqualStrings("OpenRouter", providers[0].name);
     try std.testing.expectEqualStrings("OpenRouter #2", providers[1].name);
-    try std.testing.expectEqualStrings("Anthropic #1", providers[2].name);
+    try std.testing.expectEqualStrings("Anthropic", providers[2].name);
 }
 
 test "update saved provider name only" {
@@ -1403,19 +1411,19 @@ test "add saved provider with base_url, save, load, verify round-trip" {
         defer s.deinit();
 
         try s.addSavedProvider(.{
-            .provider = "infini-ai",
-            .api_key = "sk-cp-test",
-            .model = "minimax-m2.7",
-            .base_url = "https://cloud.infini-ai.com/maas/coding/v1",
+            .provider = "custom-llm",
+            .api_key = "sk-test-key",
+            .model = "test-model",
+            .base_url = "https://example.com/v1",
         });
 
         const providers = s.savedProviders();
         try std.testing.expectEqual(@as(usize, 1), providers.len);
-        try std.testing.expectEqualStrings("infini-ai", providers[0].provider);
-        try std.testing.expectEqualStrings("sk-cp-test", providers[0].api_key);
-        try std.testing.expectEqualStrings("minimax-m2.7", providers[0].model);
-        try std.testing.expectEqualStrings("https://cloud.infini-ai.com/maas/coding/v1", providers[0].base_url);
-        try std.testing.expectEqualStrings("infini-ai #1", providers[0].name);
+        try std.testing.expectEqualStrings("custom-llm", providers[0].provider);
+        try std.testing.expectEqualStrings("sk-test-key", providers[0].api_key);
+        try std.testing.expectEqualStrings("test-model", providers[0].model);
+        try std.testing.expectEqualStrings("https://example.com/v1", providers[0].base_url);
+        try std.testing.expectEqualStrings("custom-llm #1", providers[0].name);
 
         try s.save();
     }
@@ -1426,11 +1434,11 @@ test "add saved provider with base_url, save, load, verify round-trip" {
 
         const providers = s.savedProviders();
         try std.testing.expectEqual(@as(usize, 1), providers.len);
-        try std.testing.expectEqualStrings("infini-ai", providers[0].provider);
-        try std.testing.expectEqualStrings("sk-cp-test", providers[0].api_key);
-        try std.testing.expectEqualStrings("minimax-m2.7", providers[0].model);
-        try std.testing.expectEqualStrings("https://cloud.infini-ai.com/maas/coding/v1", providers[0].base_url);
-        try std.testing.expectEqualStrings("infini-ai #1", providers[0].name);
+        try std.testing.expectEqualStrings("custom-llm", providers[0].provider);
+        try std.testing.expectEqualStrings("sk-test-key", providers[0].api_key);
+        try std.testing.expectEqualStrings("test-model", providers[0].model);
+        try std.testing.expectEqualStrings("https://example.com/v1", providers[0].base_url);
+        try std.testing.expectEqualStrings("custom-llm #1", providers[0].name);
     }
 }
 
@@ -1444,7 +1452,7 @@ test "update saved provider base_url" {
     defer s.deinit();
 
     try s.addSavedProvider(.{
-        .provider = "infini-ai",
+        .provider = "custom-llm",
         .api_key = "key1",
         .base_url = "https://old.example.com/v1",
     });
@@ -1467,9 +1475,9 @@ test "update saved provider clears base_url" {
     defer s.deinit();
 
     try s.addSavedProvider(.{
-        .provider = "infini-ai",
+        .provider = "custom-llm",
         .api_key = "key1",
-        .base_url = "https://cloud.infini-ai.com/v1",
+        .base_url = "https://example.com/v1",
     });
     const updated = try s.updateSavedProvider(1, .{ .base_url = "" });
     try std.testing.expect(updated);
@@ -1488,33 +1496,33 @@ test "multiple openai-compatible providers with different names" {
     defer s.deinit();
 
     try s.addSavedProvider(.{
-        .provider = "infini-ai",
+        .provider = "custom-llm",
         .api_key = "key1",
-        .model = "minimax-m2.7",
-        .base_url = "https://cloud.infini-ai.com/maas/coding/v1",
+        .model = "test-model",
+        .base_url = "https://example.com/v1",
     });
     try s.addSavedProvider(.{
-        .provider = "infini-ai",
+        .provider = "custom-llm",
         .api_key = "key1",
         .model = "deepseek-v3",
-        .base_url = "https://cloud.infini-ai.com/maas/coding/v1",
+        .base_url = "https://example.com/v1",
     });
     try s.addSavedProvider(.{
-        .provider = "xiaomi-mimo",
+        .provider = "another-llm",
         .api_key = "key2",
-        .model = "mimo-7b",
-        .base_url = "https://api.xiaomi.com/v1",
+        .model = "another-model",
+        .base_url = "https://other.example.com/v1",
     });
 
     const providers = s.savedProviders();
     try std.testing.expectEqual(@as(usize, 3), providers.len);
-    try std.testing.expectEqualStrings("infini-ai #1", providers[0].name);
-    try std.testing.expectEqualStrings("infini-ai #2", providers[1].name);
-    try std.testing.expectEqualStrings("xiaomi-mimo #1", providers[2].name);
-    try std.testing.expectEqualStrings("infini-ai", providers[0].provider);
-    try std.testing.expectEqualStrings("xiaomi-mimo", providers[2].provider);
-    try std.testing.expectEqualStrings("https://cloud.infini-ai.com/maas/coding/v1", providers[0].base_url);
-    try std.testing.expectEqualStrings("https://api.xiaomi.com/v1", providers[2].base_url);
+    try std.testing.expectEqualStrings("custom-llm", providers[0].name);
+    try std.testing.expectEqualStrings("custom-llm #2", providers[1].name);
+    try std.testing.expectEqualStrings("another-llm", providers[2].name);
+    try std.testing.expectEqualStrings("custom-llm", providers[0].provider);
+    try std.testing.expectEqualStrings("another-llm", providers[2].provider);
+    try std.testing.expectEqualStrings("https://example.com/v1", providers[0].base_url);
+    try std.testing.expectEqualStrings("https://other.example.com/v1", providers[2].base_url);
 }
 
 test "openai-compatible provider base_url defaults to empty" {
@@ -1556,7 +1564,7 @@ test "add saved channel, save, load, verify round-trip" {
         try std.testing.expectEqualStrings("telegram", channels[0].channel_type);
         try std.testing.expectEqualStrings("@mybot", channels[0].account);
         try std.testing.expectEqualStrings("{\"token\":\"abc\"}", channels[0].config);
-        try std.testing.expectEqualStrings("Telegram #1", channels[0].name);
+        try std.testing.expectEqualStrings("Telegram", channels[0].name);
         try std.testing.expectEqual(@as(u32, 1), channels[0].id);
 
         try s.save();
@@ -1570,7 +1578,7 @@ test "add saved channel, save, load, verify round-trip" {
         try std.testing.expectEqual(@as(usize, 1), channels.len);
         try std.testing.expectEqualStrings("telegram", channels[0].channel_type);
         try std.testing.expectEqualStrings("@mybot", channels[0].account);
-        try std.testing.expectEqualStrings("Telegram #1", channels[0].name);
+        try std.testing.expectEqualStrings("Telegram", channels[0].name);
         try std.testing.expectEqual(@as(u32, 1), channels[0].id);
     }
 }
@@ -1590,9 +1598,9 @@ test "channel auto-generated name increments per type" {
 
     const channels = s.savedChannels();
     try std.testing.expectEqual(@as(usize, 3), channels.len);
-    try std.testing.expectEqualStrings("Telegram #1", channels[0].name);
+    try std.testing.expectEqualStrings("Telegram", channels[0].name);
     try std.testing.expectEqualStrings("Telegram #2", channels[1].name);
-    try std.testing.expectEqualStrings("Discord #1", channels[2].name);
+    try std.testing.expectEqualStrings("Discord", channels[2].name);
 }
 
 test "update saved channel name only" {

--- a/src/core/state.zig
+++ b/src/core/state.zig
@@ -651,11 +651,12 @@ pub const State = struct {
         return false;
     }
 
-    pub fn hasSavedProvider(self: *State, provider: []const u8, api_key: []const u8, model: []const u8) bool {
+    pub fn hasSavedProvider(self: *State, provider: []const u8, api_key: []const u8, model: []const u8, base_url: []const u8) bool {
         for (self.saved_providers.items) |sp| {
             if (std.mem.eql(u8, sp.provider, provider) and
                 std.mem.eql(u8, sp.api_key, api_key) and
-                std.mem.eql(u8, sp.model, model))
+                std.mem.eql(u8, sp.model, model) and
+                std.mem.eql(u8, sp.base_url, base_url))
             {
                 return true;
             }
@@ -663,11 +664,12 @@ pub const State = struct {
         return false;
     }
 
-    pub fn findSavedProviderId(self: *State, provider: []const u8, api_key: []const u8, model: []const u8) ?u32 {
+    pub fn findSavedProviderId(self: *State, provider: []const u8, api_key: []const u8, model: []const u8, base_url: []const u8) ?u32 {
         for (self.saved_providers.items) |sp| {
             if (std.mem.eql(u8, sp.provider, provider) and
                 std.mem.eql(u8, sp.api_key, api_key) and
-                std.mem.eql(u8, sp.model, model))
+                std.mem.eql(u8, sp.model, model) and
+                std.mem.eql(u8, sp.base_url, base_url))
             {
                 return sp.id;
             }
@@ -1523,6 +1525,33 @@ test "multiple openai-compatible providers with different names" {
     try std.testing.expectEqualStrings("another-llm", providers[2].provider);
     try std.testing.expectEqualStrings("https://example.com/v1", providers[0].base_url);
     try std.testing.expectEqualStrings("https://other.example.com/v1", providers[2].base_url);
+}
+
+test "find saved provider distinguishes base_url" {
+    const allocator = std.testing.allocator;
+    const path = try testPath(allocator, "state.json");
+    defer allocator.free(path);
+    defer cleanupTestDir();
+
+    var s = State.init(allocator, path);
+    defer s.deinit();
+
+    try s.addSavedProvider(.{
+        .provider = "custom-llm",
+        .api_key = "key1",
+        .model = "test-model",
+        .base_url = "https://one.example.com/v1",
+    });
+    try s.addSavedProvider(.{
+        .provider = "custom-llm",
+        .api_key = "key1",
+        .model = "test-model",
+        .base_url = "https://two.example.com/v1",
+    });
+
+    try std.testing.expectEqual(@as(?u32, 1), s.findSavedProviderId("custom-llm", "key1", "test-model", "https://one.example.com/v1"));
+    try std.testing.expectEqual(@as(?u32, 2), s.findSavedProviderId("custom-llm", "key1", "test-model", "https://two.example.com/v1"));
+    try std.testing.expectEqual(@as(?u32, null), s.findSavedProviderId("custom-llm", "key1", "test-model", "https://three.example.com/v1"));
 }
 
 test "openai-compatible provider base_url defaults to empty" {

--- a/src/installer/orchestrator.zig
+++ b/src/installer/orchestrator.zig
@@ -207,20 +207,14 @@ pub fn install(
 
     // 5. Run --from-json to generate config (component owns its config generation)
     // Inject the resolved port and instance home so generated configs align with supervisor state.
-    // If the primary provider is openai-compatible (has a base_url), strip it from the answers
-    // before passing to the binary — the binary only knows standard provider names.  We will
-    // inject the custom provider credentials into the generated config afterwards.
-    const custom_provider_result = extractCustomProvider(allocator, opts.answers_json) catch |err| blk: {
-        std.log.warn("extractCustomProvider failed: {s}", .{@errorName(err)});
+    // If any selected provider is openai-compatible (has a base_url), strip only those
+    // entries before passing answers to the binary. The binary only knows standard
+    // provider names; custom credentials and fallback order are restored afterwards.
+    const custom_provider_result = extractCustomProviders(allocator, opts.answers_json) catch |err| blk: {
+        std.log.warn("extractCustomProviders failed: {s}", .{@errorName(err)});
         break :blk null;
     };
-    defer if (custom_provider_result) |cp| {
-        allocator.free(cp.custom.provider);
-        allocator.free(cp.custom.api_key);
-        allocator.free(cp.custom.base_url);
-        allocator.free(cp.custom.model);
-        allocator.free(cp.stripped_json);
-    };
+    defer if (custom_provider_result) |cp| cp.deinit(allocator);
     const answers_for_binary = if (custom_provider_result) |cp| cp.stripped_json else opts.answers_json;
 
     const answers_with_port = injectPortFields(allocator, answers_for_binary, port, managed_port) catch answers_for_binary;
@@ -250,14 +244,14 @@ pub fn install(
         return error.ConfigGenerationFailed;
     }
 
-    // If there was a custom (openai-compatible) provider, patch its credentials
-    // into the generated config now that the binary has written it.
+    // If there were custom (openai-compatible) providers, patch their credentials
+    // and the original provider order into the generated config now that the binary has written it.
     if (custom_provider_result) |cp| {
         const config_path = p.instanceConfig(allocator, opts.component, opts.instance_name) catch null;
         defer if (config_path) |path| allocator.free(path);
         if (config_path) |path| {
-            patchProviderIntoConfig(allocator, path, cp.custom.provider, cp.custom.api_key, cp.custom.base_url, cp.custom.model) catch |err| {
-                std.log.warn("failed to inject custom provider into config: {s}", .{@errorName(err)});
+            patchCustomProvidersIntoConfig(allocator, path, cp.selections, cp.custom_providers) catch |err| {
+                std.log.warn("failed to inject custom providers into config: {s}", .{@errorName(err)});
             };
         }
     }
@@ -582,16 +576,137 @@ const CustomProvider = struct {
     model: []const u8,
 };
 
-/// If the wizard answers contain a top-level `base_url` (indicating the user
-/// chose an OpenAI-compatible / custom endpoint), return the custom provider
-/// fields and a NEW answers JSON string with those fields cleared so the
-/// component binary does not see an unknown provider name.
+const ProviderSelection = struct {
+    provider: []const u8,
+    api_key: []const u8,
+    base_url: []const u8,
+    model: []const u8,
+};
+
+const CustomProvidersRewrite = struct {
+    custom_providers: []CustomProvider,
+    selections: []ProviderSelection,
+    stripped_json: []const u8,
+
+    fn deinit(self: CustomProvidersRewrite, allocator: std.mem.Allocator) void {
+        freeCustomProviders(allocator, self.custom_providers);
+        freeProviderSelections(allocator, self.selections);
+        allocator.free(self.stripped_json);
+    }
+};
+
+fn freeCustomProviders(allocator: std.mem.Allocator, providers: []CustomProvider) void {
+    for (providers) |provider| {
+        allocator.free(provider.provider);
+        allocator.free(provider.api_key);
+        allocator.free(provider.base_url);
+        allocator.free(provider.model);
+    }
+    allocator.free(providers);
+}
+
+fn deinitCustomProviderList(allocator: std.mem.Allocator, providers: *std.array_list.Managed(CustomProvider)) void {
+    for (providers.items) |provider| {
+        allocator.free(provider.provider);
+        allocator.free(provider.api_key);
+        allocator.free(provider.base_url);
+        allocator.free(provider.model);
+    }
+    providers.deinit();
+}
+
+fn freeProviderSelections(allocator: std.mem.Allocator, selections: []ProviderSelection) void {
+    for (selections) |selection| {
+        allocator.free(selection.provider);
+        allocator.free(selection.api_key);
+        allocator.free(selection.base_url);
+        allocator.free(selection.model);
+    }
+    allocator.free(selections);
+}
+
+fn deinitProviderSelectionList(allocator: std.mem.Allocator, selections: *std.array_list.Managed(ProviderSelection)) void {
+    for (selections.items) |selection| {
+        allocator.free(selection.provider);
+        allocator.free(selection.api_key);
+        allocator.free(selection.base_url);
+        allocator.free(selection.model);
+    }
+    selections.deinit();
+}
+
+fn stringField(obj: *std.json.ObjectMap, key: []const u8) []const u8 {
+    return switch (obj.get(key) orelse .null) {
+        .string => |s| s,
+        else => "",
+    };
+}
+
+fn appendProviderSelection(
+    allocator: std.mem.Allocator,
+    selections: *std.array_list.Managed(ProviderSelection),
+    provider: []const u8,
+    api_key: []const u8,
+    base_url: []const u8,
+    model: []const u8,
+) !void {
+    if (provider.len == 0) return;
+    const owned_provider = try allocator.dupe(u8, provider);
+    errdefer allocator.free(owned_provider);
+    const owned_api_key = try allocator.dupe(u8, api_key);
+    errdefer allocator.free(owned_api_key);
+    const owned_base_url = try allocator.dupe(u8, base_url);
+    errdefer allocator.free(owned_base_url);
+    const owned_model = try allocator.dupe(u8, model);
+    errdefer allocator.free(owned_model);
+    try selections.append(.{
+        .provider = owned_provider,
+        .api_key = owned_api_key,
+        .base_url = owned_base_url,
+        .model = owned_model,
+    });
+}
+
+fn appendCustomProvider(
+    allocator: std.mem.Allocator,
+    providers: *std.array_list.Managed(CustomProvider),
+    provider: []const u8,
+    api_key: []const u8,
+    base_url: []const u8,
+    model: []const u8,
+) !void {
+    if (provider.len == 0 or base_url.len == 0) return;
+    const owned_provider = try allocator.dupe(u8, provider);
+    errdefer allocator.free(owned_provider);
+    const owned_api_key = try allocator.dupe(u8, api_key);
+    errdefer allocator.free(owned_api_key);
+    const owned_base_url = try allocator.dupe(u8, base_url);
+    errdefer allocator.free(owned_base_url);
+    const owned_model = try allocator.dupe(u8, model);
+    errdefer allocator.free(owned_model);
+    try providers.append(.{
+        .provider = owned_provider,
+        .api_key = owned_api_key,
+        .base_url = owned_base_url,
+        .model = owned_model,
+    });
+}
+
+fn neutralizeProviderObject(allocator: std.mem.Allocator, obj: *std.json.ObjectMap) !void {
+    try obj.put(allocator, "provider", .{ .string = "openai" });
+    try obj.put(allocator, "api_key", .{ .string = "" });
+    try obj.put(allocator, "model", .{ .string = "" });
+    try obj.put(allocator, "base_url", .{ .string = "" });
+}
+
+/// If the wizard answers contain any provider with a non-empty `base_url`
+/// (indicating an OpenAI-compatible / custom endpoint), return all custom
+/// provider fields, the original provider order, and a NEW answers JSON string
+/// with only custom entries neutralized so the component binary does not see
+/// unknown provider names.
 ///
 /// Returns `null` when no custom provider is present (standard flow).
-fn extractCustomProvider(allocator: std.mem.Allocator, json: []const u8) !?struct {
-    custom: CustomProvider,
-    stripped_json: []const u8,
-} {
+fn extractCustomProviders(allocator: std.mem.Allocator, json: []const u8) !?CustomProvidersRewrite {
     var parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{
         .allocate = .alloc_always,
         .ignore_unknown_fields = true,
@@ -601,77 +716,100 @@ fn extractCustomProvider(allocator: std.mem.Allocator, json: []const u8) !?struc
 
     const root = &parsed.value.object;
 
-    // A non-empty top-level `base_url` means this is a custom/openai-compatible
-    // provider that the component binary will not recognise.
-    const base_url_val = root.get("base_url") orelse return null;
-    const base_url = switch (base_url_val) {
-        .string => |s| s,
-        else => return null,
-    };
-    if (base_url.len == 0) return null;
+    var custom_providers = std.array_list.Managed(CustomProvider).init(allocator);
+    errdefer deinitCustomProviderList(allocator, &custom_providers);
+    var selections = std.array_list.Managed(ProviderSelection).init(allocator);
+    errdefer deinitProviderSelectionList(allocator, &selections);
 
-    const provider = switch (root.get("provider") orelse .null) {
-        .string => |s| s,
-        else => "",
-    };
-    const api_key = switch (root.get("api_key") orelse .null) {
-        .string => |s| s,
-        else => "",
-    };
-    const model = switch (root.get("model") orelse .null) {
-        .string => |s| s,
-        else => "",
-    };
-
-    // Duplicate the strings before parsed is deinitialized.
-    const cp = CustomProvider{
-        .provider = try allocator.dupe(u8, provider),
-        .api_key = try allocator.dupe(u8, api_key),
-        .base_url = try allocator.dupe(u8, base_url),
-        .model = try allocator.dupe(u8, model),
-    };
-
-    // Replace provider-specific fields with a known standard provider so the
-    // binary generates a valid base config without failing on the custom name.
-    // The real credentials are injected into the config file after the binary runs.
-    try root.put(allocator, "provider", .{ .string = "openai" });
-    try root.put(allocator, "api_key", .{ .string = "" });
-    try root.put(allocator, "model", .{ .string = "" });
-    try root.put(allocator, "base_url", .{ .string = "" });
-
-    // Also neutralise the `providers` array that the wizard sends alongside the
-    // top-level fields — nullclaw reads from both, and leaving the custom name
-    // in the array is what caused "UNKNOWN PROVIDER '<name>'" errors.
+    var saw_providers_array = false;
     if (root.getPtr("providers")) |arr_val| {
         if (arr_val.* == .array) {
+            saw_providers_array = true;
             for (arr_val.array.items) |*item| {
                 if (item.* != .object) continue;
-                try item.object.put(allocator, "provider", .{ .string = "openai" });
-                try item.object.put(allocator, "api_key", .{ .string = "" });
-                try item.object.put(allocator, "model", .{ .string = "" });
-                try item.object.put(allocator, "base_url", .{ .string = "" });
+                const provider = stringField(&item.object, "provider");
+                const api_key = stringField(&item.object, "api_key");
+                const base_url = stringField(&item.object, "base_url");
+                const model = stringField(&item.object, "model");
+
+                try appendProviderSelection(allocator, &selections, provider, api_key, base_url, model);
+
+                if (base_url.len > 0) {
+                    try appendCustomProvider(allocator, &custom_providers, provider, api_key, base_url, model);
+                    try neutralizeProviderObject(allocator, &item.object);
+                }
             }
         }
     }
 
+    const top_provider = stringField(root, "provider");
+    const top_api_key = stringField(root, "api_key");
+    const top_base_url = stringField(root, "base_url");
+    const top_model = stringField(root, "model");
+
+    if (!saw_providers_array) {
+        try appendProviderSelection(allocator, &selections, top_provider, top_api_key, top_base_url, top_model);
+        if (top_base_url.len > 0) {
+            try appendCustomProvider(allocator, &custom_providers, top_provider, top_api_key, top_base_url, top_model);
+        }
+    }
+
+    if (top_base_url.len > 0) {
+        try neutralizeProviderObject(allocator, root);
+    }
+
+    if (custom_providers.items.len == 0) {
+        deinitCustomProviderList(allocator, &custom_providers);
+        deinitProviderSelectionList(allocator, &selections);
+        return null;
+    }
+
+    const custom_slice = try custom_providers.toOwnedSlice();
+    errdefer freeCustomProviders(allocator, custom_slice);
+    const selection_slice = try selections.toOwnedSlice();
+    errdefer freeProviderSelections(allocator, selection_slice);
     const stripped = try std.json.Stringify.valueAlloc(allocator, parsed.value, .{});
-    return .{ .custom = cp, .stripped_json = stripped };
+    return .{
+        .custom_providers = custom_slice,
+        .selections = selection_slice,
+        .stripped_json = stripped,
+    };
 }
 
-/// Patch provider credentials into an existing instance config file.
-/// Navigates/creates `models → providers → <provider>` and sets `api_key`
-/// (always) and `base_url` (when non-empty).  Also removes the `openai`
-/// placeholder left by `extractCustomProvider`, and sets
-/// `agents → defaults → model → primary` to `"<provider>/<model>"` when
-/// model is non-empty.  Best-effort: errors are returned so the caller can
-/// decide whether to surface them.
-fn patchProviderIntoConfig(
+fn selectionContainsProvider(selections: []const ProviderSelection, provider: []const u8) bool {
+    for (selections) |selection| {
+        if (std.mem.eql(u8, selection.provider, provider)) return true;
+    }
+    return false;
+}
+
+fn putFallbackProviders(
+    allocator: std.mem.Allocator,
+    root: *std.json.ObjectMap,
+    selections: []const ProviderSelection,
+) !void {
+    const reliability_obj = try ensureObjectInMap(allocator, root, "reliability");
+    var fallbacks = std.json.Array.init(allocator);
+    errdefer fallbacks.deinit();
+
+    if (selections.len > 1) {
+        for (selections[1..]) |selection| {
+            if (selection.provider.len == 0) continue;
+            try fallbacks.append(.{ .string = selection.provider });
+        }
+    }
+
+    try reliability_obj.put(allocator, "fallback_providers", .{ .array = fallbacks });
+}
+
+/// Patch custom provider credentials and original provider order into an
+/// existing instance config file after the component binary generates its base
+/// config with placeholder OpenAI entries.
+fn patchCustomProvidersIntoConfig(
     allocator: std.mem.Allocator,
     config_path: []const u8,
-    provider: []const u8,
-    api_key: []const u8,
-    base_url: []const u8,
-    model: []const u8,
+    selections: []const ProviderSelection,
+    custom_providers: []const CustomProvider,
 ) !void {
     const contents = blk: {
         const file = std_compat.fs.openFileAbsolute(config_path, .{}) catch |err| switch (err) {
@@ -695,36 +833,34 @@ fn patchProviderIntoConfig(
 
     const models_obj = try ensureObjectInMap(ja, root, "models");
     const providers_obj = try ensureObjectInMap(ja, models_obj, "providers");
-    const provider_obj = try ensureObjectInMap(ja, providers_obj, provider);
 
-    try provider_obj.put(ja, "api_key", .{ .string = api_key });
-    if (base_url.len > 0) {
-        try provider_obj.put(ja, "base_url", .{ .string = base_url });
+    for (selections) |selection| {
+        const provider_obj = try ensureObjectInMap(ja, providers_obj, selection.provider);
+        try provider_obj.put(ja, "api_key", .{ .string = selection.api_key });
+        if (selection.base_url.len > 0) {
+            try provider_obj.put(ja, "base_url", .{ .string = selection.base_url });
+        } else {
+            _ = provider_obj.orderedRemove("base_url");
+        }
     }
 
-    // Remove the "openai" placeholder that extractCustomProvider injected so
-    // the binary could generate a valid base config.  Only remove it when the
-    // real provider name differs (avoids accidentally deleting a genuine openai
-    // entry if someone names their custom provider "openai").
-    if (!std.mem.eql(u8, provider, "openai")) {
+    // Remove the placeholder unless the user's actual provider order includes OpenAI.
+    if (!selectionContainsProvider(selections, "openai")) {
         _ = providers_obj.orderedRemove("openai");
     }
 
-    // Patch agents → defaults → model → primary to "<provider>/<model>".
-    if (model.len > 0) {
-        const primary = try std.fmt.allocPrint(ja, "{s}/{s}", .{ provider, model });
+    if (selections.len > 0 and selections[0].model.len > 0) {
+        const primary = try std.fmt.allocPrint(ja, "{s}/{s}", .{ selections[0].provider, selections[0].model });
         const agents_obj = try ensureObjectInMap(ja, root, "agents");
         const defaults_obj = try ensureObjectInMap(ja, agents_obj, "defaults");
         const model_obj = try ensureObjectInMap(ja, defaults_obj, "model");
         try model_obj.put(ja, "primary", .{ .string = primary });
+    }
 
-        // Custom providers (with a base_url) may expose text-only models.
-        // vision_disabled_models is used at inference time to strip image
-        // markers from messages sent to the model; it does not suppress the
-        // startup vision probe.  We still populate it so that once the probe
-        // has run (and the instance is stable), vision content is stripped
-        // correctly on every subsequent request.
-        if (base_url.len > 0) {
+    try putFallbackProviders(ja, root, selections);
+
+    for (custom_providers) |custom| {
+        if (custom.model.len > 0) {
             const agent_obj = try ensureObjectInMap(ja, root, "agent");
             const vd_gop = try agent_obj.getOrPut(ja, "vision_disabled_models");
             if (!vd_gop.found_existing) {
@@ -733,13 +869,13 @@ fn patchProviderIntoConfig(
             if (vd_gop.value_ptr.* == .array) {
                 var already_present = false;
                 for (vd_gop.value_ptr.array.items) |item| {
-                    if (item == .string and std.mem.eql(u8, item.string, model)) {
+                    if (item == .string and std.mem.eql(u8, item.string, custom.model)) {
                         already_present = true;
                         break;
                     }
                 }
                 if (!already_present) {
-                    try vd_gop.value_ptr.array.append(.{ .string = model });
+                    try vd_gop.value_ptr.array.append(.{ .string = custom.model });
                 }
             }
         }
@@ -1222,4 +1358,148 @@ test "injectHomeField adds home to JSON object" {
     defer allocator.free(result);
     try std.testing.expect(std.mem.indexOf(u8, result, "\"home\":\"/tmp/inst\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, result, "\"provider\":\"openrouter\"") != null);
+}
+
+test "extractCustomProviders neutralizes custom fallback while preserving standard primary" {
+    const allocator = std.testing.allocator;
+    const json =
+        \\{"provider":"openrouter","api_key":"sk-or","model":"openrouter/auto","providers":[{"provider":"openrouter","api_key":"sk-or","model":"openrouter/auto"},{"provider":"local-llm","api_key":"sk-local","model":"llama3","base_url":"http://127.0.0.1:5801/v1"}]}
+    ;
+
+    const rewrite = (try extractCustomProviders(allocator, json)).?;
+    defer rewrite.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), rewrite.custom_providers.len);
+    try std.testing.expectEqualStrings("local-llm", rewrite.custom_providers[0].provider);
+    try std.testing.expectEqual(@as(usize, 2), rewrite.selections.len);
+    try std.testing.expectEqualStrings("openrouter", rewrite.selections[0].provider);
+    try std.testing.expectEqualStrings("local-llm", rewrite.selections[1].provider);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, rewrite.stripped_json, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    });
+    defer parsed.deinit();
+    const providers = parsed.value.object.get("providers").?.array.items;
+    try std.testing.expectEqualStrings("openrouter", providers[0].object.get("provider").?.string);
+    try std.testing.expectEqualStrings("openai", providers[1].object.get("provider").?.string);
+    try std.testing.expectEqualStrings("", providers[1].object.get("base_url").?.string);
+}
+
+test "extractCustomProviders neutralizes primary custom without dropping standard fallback" {
+    const allocator = std.testing.allocator;
+    const json =
+        \\{"provider":"local-llm","api_key":"sk-local","model":"llama3","base_url":"http://127.0.0.1:5801/v1","providers":[{"provider":"local-llm","api_key":"sk-local","model":"llama3","base_url":"http://127.0.0.1:5801/v1"},{"provider":"openrouter","api_key":"sk-or","model":"openrouter/auto"}]}
+    ;
+
+    const rewrite = (try extractCustomProviders(allocator, json)).?;
+    defer rewrite.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), rewrite.custom_providers.len);
+    try std.testing.expectEqualStrings("local-llm", rewrite.custom_providers[0].provider);
+    try std.testing.expectEqual(@as(usize, 2), rewrite.selections.len);
+    try std.testing.expectEqualStrings("local-llm", rewrite.selections[0].provider);
+    try std.testing.expectEqualStrings("openrouter", rewrite.selections[1].provider);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, rewrite.stripped_json, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    });
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("openai", parsed.value.object.get("provider").?.string);
+    try std.testing.expectEqualStrings("", parsed.value.object.get("base_url").?.string);
+    const providers = parsed.value.object.get("providers").?.array.items;
+    try std.testing.expectEqualStrings("openai", providers[0].object.get("provider").?.string);
+    try std.testing.expectEqualStrings("openrouter", providers[1].object.get("provider").?.string);
+}
+
+test "patchCustomProvidersIntoConfig restores custom fallback provider order" {
+    const allocator = std.testing.allocator;
+    const tmp_dir = "/tmp/test-orchestrator-custom-fallback-patch";
+    std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    try std_compat.fs.makeDirAbsolute(tmp_dir);
+    defer std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+
+    const config_path = try std.fs.path.join(allocator, &.{ tmp_dir, "config.json" });
+    defer allocator.free(config_path);
+    try writeFile(config_path,
+        \\{"models":{"providers":{"openrouter":{"api_key":"sk-or"},"openai":{"api_key":""}}},"agents":{"defaults":{"model":{"primary":"openrouter/openrouter-auto"}}},"reliability":{"fallback_providers":["openai"]}}
+    );
+
+    const selections = [_]ProviderSelection{
+        .{ .provider = "openrouter", .api_key = "sk-or", .base_url = "", .model = "openrouter-auto" },
+        .{ .provider = "local-llm", .api_key = "sk-local", .base_url = "http://127.0.0.1:5801/v1", .model = "llama3" },
+    };
+    const custom_providers = [_]CustomProvider{
+        .{ .provider = "local-llm", .api_key = "sk-local", .base_url = "http://127.0.0.1:5801/v1", .model = "llama3" },
+    };
+
+    try patchCustomProvidersIntoConfig(allocator, config_path, &selections, &custom_providers);
+
+    const file = try std_compat.fs.openFileAbsolute(config_path, .{});
+    defer file.close();
+    const contents = try file.readToEndAlloc(allocator, 64 * 1024);
+    defer allocator.free(contents);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, contents, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    });
+    defer parsed.deinit();
+
+    const providers = parsed.value.object.get("models").?.object.get("providers").?.object;
+    try std.testing.expect(providers.get("openai") == null);
+    try std.testing.expect(providers.get("openrouter") != null);
+    const local = providers.get("local-llm").?.object;
+    try std.testing.expectEqualStrings("sk-local", local.get("api_key").?.string);
+    try std.testing.expectEqualStrings("http://127.0.0.1:5801/v1", local.get("base_url").?.string);
+
+    const primary = parsed.value.object.get("agents").?.object.get("defaults").?.object.get("model").?.object.get("primary").?.string;
+    try std.testing.expectEqualStrings("openrouter/openrouter-auto", primary);
+    const fallbacks = parsed.value.object.get("reliability").?.object.get("fallback_providers").?.array.items;
+    try std.testing.expectEqual(@as(usize, 1), fallbacks.len);
+    try std.testing.expectEqualStrings("local-llm", fallbacks[0].string);
+}
+
+test "patchCustomProvidersIntoConfig restores primary custom and keeps standard fallback" {
+    const allocator = std.testing.allocator;
+    const tmp_dir = "/tmp/test-orchestrator-primary-custom-patch";
+    std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    try std_compat.fs.makeDirAbsolute(tmp_dir);
+    defer std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+
+    const config_path = try std.fs.path.join(allocator, &.{ tmp_dir, "config.json" });
+    defer allocator.free(config_path);
+    try writeFile(config_path,
+        \\{"models":{"providers":{"openai":{"api_key":""},"openrouter":{"api_key":"sk-or"}}},"agents":{"defaults":{"model":{"primary":"openai/"}}},"reliability":{"fallback_providers":["openrouter"]}}
+    );
+
+    const selections = [_]ProviderSelection{
+        .{ .provider = "local-llm", .api_key = "sk-local", .base_url = "http://127.0.0.1:5801/v1", .model = "llama3" },
+        .{ .provider = "openrouter", .api_key = "sk-or", .base_url = "", .model = "openrouter-auto" },
+    };
+    const custom_providers = [_]CustomProvider{
+        .{ .provider = "local-llm", .api_key = "sk-local", .base_url = "http://127.0.0.1:5801/v1", .model = "llama3" },
+    };
+
+    try patchCustomProvidersIntoConfig(allocator, config_path, &selections, &custom_providers);
+
+    const file = try std_compat.fs.openFileAbsolute(config_path, .{});
+    defer file.close();
+    const contents = try file.readToEndAlloc(allocator, 64 * 1024);
+    defer allocator.free(contents);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, contents, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    });
+    defer parsed.deinit();
+
+    const providers = parsed.value.object.get("models").?.object.get("providers").?.object;
+    try std.testing.expect(providers.get("openai") == null);
+    try std.testing.expect(providers.get("openrouter") != null);
+    try std.testing.expect(providers.get("local-llm") != null);
+    const primary = parsed.value.object.get("agents").?.object.get("defaults").?.object.get("model").?.object.get("primary").?.string;
+    try std.testing.expectEqualStrings("local-llm/llama3", primary);
+    const fallbacks = parsed.value.object.get("reliability").?.object.get("fallback_providers").?.array.items;
+    try std.testing.expectEqual(@as(usize, 1), fallbacks.len);
+    try std.testing.expectEqualStrings("openrouter", fallbacks[0].string);
 }

--- a/src/installer/orchestrator.zig
+++ b/src/installer/orchestrator.zig
@@ -221,6 +221,7 @@ pub fn install(
         allocator.free(cp.custom.provider);
         allocator.free(cp.custom.api_key);
         allocator.free(cp.custom.base_url);
+        allocator.free(cp.custom.model);
         allocator.free(cp.stripped_json);
     };
     const answers_for_binary = if (custom_provider_result) |cp| cp.stripped_json else opts.answers_json;
@@ -258,7 +259,7 @@ pub fn install(
         const config_path = p.instanceConfig(allocator, opts.component, opts.instance_name) catch null;
         defer if (config_path) |path| allocator.free(path);
         if (config_path) |path| {
-            patchProviderIntoConfig(allocator, path, cp.custom.provider, cp.custom.api_key, cp.custom.base_url) catch |err| {
+            patchProviderIntoConfig(allocator, path, cp.custom.provider, cp.custom.api_key, cp.custom.base_url, cp.custom.model) catch |err| {
                 std.debug.print("warning: failed to inject custom provider into config: {s}\n", .{@errorName(err)});
             };
         }
@@ -581,6 +582,7 @@ const CustomProvider = struct {
     provider: []const u8,
     api_key: []const u8,
     base_url: []const u8,
+    model: []const u8,
 };
 
 /// If the wizard answers contain a top-level `base_url` (indicating the user
@@ -619,12 +621,17 @@ fn extractCustomProvider(allocator: std.mem.Allocator, json: []const u8) !?struc
         .string => |s| s,
         else => "",
     };
+    const model = switch (root.get("model") orelse .null) {
+        .string => |s| s,
+        else => "",
+    };
 
     // Duplicate the strings before parsed is deinitialized.
     const cp = CustomProvider{
         .provider = try allocator.dupe(u8, provider),
         .api_key = try allocator.dupe(u8, api_key),
         .base_url = try allocator.dupe(u8, base_url),
+        .model = try allocator.dupe(u8, model),
     };
 
     // Replace provider-specific fields with a known standard provider so the
@@ -657,14 +664,18 @@ fn extractCustomProvider(allocator: std.mem.Allocator, json: []const u8) !?struc
 
 /// Patch provider credentials into an existing instance config file.
 /// Navigates/creates `models → providers → <provider>` and sets `api_key`
-/// (always) and `base_url` (when non-empty).  Best-effort: errors are returned
-/// so the caller can decide whether to surface them.
+/// (always) and `base_url` (when non-empty).  Also removes the `openai`
+/// placeholder left by `extractCustomProvider`, and sets
+/// `agents → defaults → model → primary` to `"<provider>/<model>"` when
+/// model is non-empty.  Best-effort: errors are returned so the caller can
+/// decide whether to surface them.
 fn patchProviderIntoConfig(
     allocator: std.mem.Allocator,
     config_path: []const u8,
     provider: []const u8,
     api_key: []const u8,
     base_url: []const u8,
+    model: []const u8,
 ) !void {
     const contents = blk: {
         const file = std_compat.fs.openFileAbsolute(config_path, .{}) catch |err| switch (err) {
@@ -693,6 +704,23 @@ fn patchProviderIntoConfig(
     try provider_obj.put(ja, "api_key", .{ .string = api_key });
     if (base_url.len > 0) {
         try provider_obj.put(ja, "base_url", .{ .string = base_url });
+    }
+
+    // Remove the "openai" placeholder that extractCustomProvider injected so
+    // the binary could generate a valid base config.  Only remove it when the
+    // real provider name differs (avoids accidentally deleting a genuine openai
+    // entry if someone names their custom provider "openai").
+    if (!std.mem.eql(u8, provider, "openai")) {
+        _ = providers_obj.orderedRemove("openai");
+    }
+
+    // Patch agents → defaults → model → primary to "<provider>/<model>".
+    if (model.len > 0) {
+        const primary = try std.fmt.allocPrint(ja, "{s}/{s}", .{ provider, model });
+        const agents_obj = try ensureObjectInMap(ja, root, "agents");
+        const defaults_obj = try ensureObjectInMap(ja, agents_obj, "defaults");
+        const model_obj = try ensureObjectInMap(ja, defaults_obj, "model");
+        try model_obj.put(ja, "primary", .{ .string = primary });
     }
 
     const rendered = try std.json.Stringify.valueAlloc(allocator, parsed.value, .{

--- a/src/installer/orchestrator.zig
+++ b/src/installer/orchestrator.zig
@@ -721,6 +721,30 @@ fn patchProviderIntoConfig(
         const defaults_obj = try ensureObjectInMap(ja, agents_obj, "defaults");
         const model_obj = try ensureObjectInMap(ja, defaults_obj, "model");
         try model_obj.put(ja, "primary", .{ .string = primary });
+
+        // Custom providers (with a base_url) may expose models whose vision
+        // probe hangs indefinitely, blocking the gateway HTTP handler during
+        // startup and causing the supervisor health-check to time out.  Adding
+        // the model to vision_disabled_models skips the probe entirely.
+        if (base_url.len > 0) {
+            const agent_obj = try ensureObjectInMap(ja, root, "agent");
+            const vd_gop = try agent_obj.getOrPut(ja, "vision_disabled_models");
+            if (!vd_gop.found_existing) {
+                vd_gop.value_ptr.* = .{ .array = std.json.Array.init(ja) };
+            }
+            if (vd_gop.value_ptr.* == .array) {
+                var already_present = false;
+                for (vd_gop.value_ptr.array.items) |item| {
+                    if (item == .string and std.mem.eql(u8, item.string, model)) {
+                        already_present = true;
+                        break;
+                    }
+                }
+                if (!already_present) {
+                    try vd_gop.value_ptr.array.append(.{ .string = model });
+                }
+            }
+        }
     }
 
     const rendered = try std.json.Stringify.valueAlloc(allocator, parsed.value, .{

--- a/src/installer/orchestrator.zig
+++ b/src/installer/orchestrator.zig
@@ -207,8 +207,20 @@ pub fn install(
 
     // 5. Run --from-json to generate config (component owns its config generation)
     // Inject the resolved port and instance home so generated configs align with supervisor state.
-    const answers_with_port = injectPortFields(allocator, opts.answers_json, port, managed_port) catch opts.answers_json;
-    defer if (answers_with_port.ptr != opts.answers_json.ptr) allocator.free(answers_with_port);
+    // If the primary provider is openai-compatible (has a base_url), strip it from the answers
+    // before passing to the binary — the binary only knows standard provider names.  We will
+    // inject the custom provider credentials into the generated config afterwards.
+    const custom_provider_result = extractCustomProvider(allocator, opts.answers_json) catch null;
+    defer if (custom_provider_result) |cp| {
+        allocator.free(cp.custom.provider);
+        allocator.free(cp.custom.api_key);
+        allocator.free(cp.custom.base_url);
+        allocator.free(cp.stripped_json);
+    };
+    const answers_for_binary = if (custom_provider_result) |cp| cp.stripped_json else opts.answers_json;
+
+    const answers_with_port = injectPortFields(allocator, answers_for_binary, port, managed_port) catch answers_for_binary;
+    defer if (answers_with_port.ptr != answers_for_binary.ptr) allocator.free(answers_with_port);
     const answers_with_home = injectHomeField(allocator, answers_with_port, inst_dir) catch answers_with_port;
     defer if (answers_with_home.ptr != answers_with_port.ptr) allocator.free(answers_with_home);
 
@@ -232,6 +244,18 @@ pub fn install(
             setLastErrorDetail(from_json_result.stderr);
         }
         return error.ConfigGenerationFailed;
+    }
+
+    // If there was a custom (openai-compatible) provider, patch its credentials
+    // into the generated config now that the binary has written it.
+    if (custom_provider_result) |cp| {
+        const config_path = p.instanceConfig(allocator, opts.component, opts.instance_name) catch null;
+        defer if (config_path) |path| allocator.free(path);
+        if (config_path) |path| {
+            patchProviderIntoConfig(allocator, path, cp.custom.provider, cp.custom.api_key, cp.custom.base_url) catch |err| {
+                std.debug.print("warning: failed to inject custom provider into config: {s}\n", .{@errorName(err)});
+            };
+        }
     }
 
     _ = nullclaw_web_channel.ensureNullclawWebChannelConfig(
@@ -540,6 +564,139 @@ fn injectHomeField(allocator: std.mem.Allocator, json: []const u8, home: []const
     // Append everything after the opening brace
     try buf.appendSlice(json[start + 1 ..]);
     return buf.toOwnedSlice();
+}
+
+// ─── Custom provider handling ────────────────────────────────────────────────
+
+/// Extracted custom-provider fields stripped from wizard answers before they
+/// reach the component binary.  All slices are owned by the arena from the
+/// parsed JSON value; callers must not free them individually.
+const CustomProvider = struct {
+    provider: []const u8,
+    api_key: []const u8,
+    base_url: []const u8,
+};
+
+/// If the wizard answers contain a top-level `base_url` (indicating the user
+/// chose an OpenAI-compatible / custom endpoint), return the custom provider
+/// fields and a NEW answers JSON string with those fields cleared so the
+/// component binary does not see an unknown provider name.
+///
+/// Returns `null` when no custom provider is present (standard flow).
+fn extractCustomProvider(allocator: std.mem.Allocator, json: []const u8) !?struct {
+    custom: CustomProvider,
+    stripped_json: []const u8,
+} {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    });
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+
+    const root = &parsed.value.object;
+
+    // A non-empty top-level `base_url` means this is a custom/openai-compatible
+    // provider that the component binary will not recognise.
+    const base_url_val = root.get("base_url") orelse return null;
+    const base_url = switch (base_url_val) {
+        .string => |s| s,
+        else => return null,
+    };
+    if (base_url.len == 0) return null;
+
+    const provider = switch (root.get("provider") orelse .null) {
+        .string => |s| s,
+        else => "",
+    };
+    const api_key = switch (root.get("api_key") orelse .null) {
+        .string => |s| s,
+        else => "",
+    };
+
+    // Duplicate the strings before parsed is deinitialized.
+    const cp = CustomProvider{
+        .provider = try allocator.dupe(u8, provider),
+        .api_key = try allocator.dupe(u8, api_key),
+        .base_url = try allocator.dupe(u8, base_url),
+    };
+
+    // Clear the provider-specific fields so the binary receives no provider.
+    try root.put(allocator, "provider", .{ .string = "" });
+    try root.put(allocator, "api_key", .{ .string = "" });
+    try root.put(allocator, "model", .{ .string = "" });
+    try root.put(allocator, "base_url", .{ .string = "" });
+
+    const stripped = try std.json.Stringify.valueAlloc(allocator, parsed.value, .{});
+    return .{ .custom = cp, .stripped_json = stripped };
+}
+
+/// Patch provider credentials into an existing instance config file.
+/// Navigates/creates `models → providers → <provider>` and sets `api_key`
+/// (always) and `base_url` (when non-empty).  Best-effort: errors are returned
+/// so the caller can decide whether to surface them.
+fn patchProviderIntoConfig(
+    allocator: std.mem.Allocator,
+    config_path: []const u8,
+    provider: []const u8,
+    api_key: []const u8,
+    base_url: []const u8,
+) !void {
+    const contents = blk: {
+        const file = std_compat.fs.openFileAbsolute(config_path, .{}) catch |err| switch (err) {
+            error.FileNotFound => break :blk try allocator.dupe(u8, "{}"),
+            else => return err,
+        };
+        defer file.close();
+        break :blk try file.readToEndAlloc(allocator, 8 * 1024 * 1024);
+    };
+    defer allocator.free(contents);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, contents, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    });
+    defer parsed.deinit();
+    const ja = parsed.arena.allocator();
+
+    if (parsed.value != .object) return error.InvalidConfig;
+    const root = &parsed.value.object;
+
+    const models_obj = try ensureObjectInMap(ja, root, "models");
+    const providers_obj = try ensureObjectInMap(ja, models_obj, "providers");
+    const provider_obj = try ensureObjectInMap(ja, providers_obj, provider);
+
+    try provider_obj.put(ja, "api_key", .{ .string = api_key });
+    if (base_url.len > 0) {
+        try provider_obj.put(ja, "base_url", .{ .string = base_url });
+    }
+
+    const rendered = try std.json.Stringify.valueAlloc(allocator, parsed.value, .{
+        .whitespace = .indent_2,
+        .emit_null_optional_fields = false,
+    });
+    defer allocator.free(rendered);
+
+    const out = try std_compat.fs.createFileAbsolute(config_path, .{ .truncate = true });
+    defer out.close();
+    try out.writeAll(rendered);
+    try out.writeAll("\n");
+}
+
+fn ensureObjectInMap(
+    allocator: std.mem.Allocator,
+    obj: *std.json.ObjectMap,
+    key: []const u8,
+) !*std.json.ObjectMap {
+    const gop = try obj.getOrPut(allocator, key);
+    if (!gop.found_existing) {
+        gop.value_ptr.* = .{ .object = .empty };
+        return &gop.value_ptr.object;
+    }
+    if (gop.value_ptr.* != .object) {
+        gop.value_ptr.* = .{ .object = .empty };
+    }
+    return &gop.value_ptr.object;
 }
 
 fn stageLocalBinary(allocator: std.mem.Allocator, p: paths_mod.Paths, component: []const u8) ?struct { version: []const u8, bin_path: []const u8 } {

--- a/src/installer/orchestrator.zig
+++ b/src/installer/orchestrator.zig
@@ -693,6 +693,20 @@ fn patchProviderIntoConfig(
     if (parsed.value != .object) return error.InvalidConfig;
     const root = &parsed.value.object;
 
+    // The nullclaw-dev-local binary panics with "programmer bug caused syscall
+    // error: AGAIN" when a2a.enabled is false.  The --from-json generator
+    // always emits enabled:false for fresh installs, so patch it to true here.
+    // Leave all other a2a fields (name, description, url, version) as-is.
+    if (root.getPtr("a2a")) |a2a_val| {
+        if (a2a_val.* == .object) {
+            if (a2a_val.object.getPtr("enabled")) |enabled_val| {
+                if (enabled_val.* == .bool and !enabled_val.bool) {
+                    enabled_val.* = .{ .bool = true };
+                }
+            }
+        }
+    }
+
     const models_obj = try ensureObjectInMap(ja, root, "models");
     const providers_obj = try ensureObjectInMap(ja, models_obj, "providers");
     const provider_obj = try ensureObjectInMap(ja, providers_obj, provider);
@@ -718,10 +732,12 @@ fn patchProviderIntoConfig(
         const model_obj = try ensureObjectInMap(ja, defaults_obj, "model");
         try model_obj.put(ja, "primary", .{ .string = primary });
 
-        // Custom providers (with a base_url) may expose models whose vision
-        // probe hangs indefinitely, blocking the gateway HTTP handler during
-        // startup and causing the supervisor health-check to time out.  Adding
-        // the model to vision_disabled_models skips the probe entirely.
+        // Custom providers (with a base_url) may expose text-only models.
+        // vision_disabled_models is used at inference time to strip image
+        // markers from messages sent to the model; it does not suppress the
+        // startup vision probe.  We still populate it so that once the probe
+        // has run (and the instance is stable), vision content is stripped
+        // correctly on every subsequent request.
         if (base_url.len > 0) {
             const agent_obj = try ensureObjectInMap(ja, root, "agent");
             const vd_gop = try agent_obj.getOrPut(ja, "vision_disabled_models");
@@ -1220,4 +1236,57 @@ test "injectHomeField adds home to JSON object" {
     defer allocator.free(result);
     try std.testing.expect(std.mem.indexOf(u8, result, "\"home\":\"/tmp/inst\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, result, "\"provider\":\"openrouter\"") != null);
+}
+
+test "patchProviderIntoConfig fixes a2a.enabled false to true" {
+    const allocator = std.testing.allocator;
+    const tmp_dir = "/tmp/test-patch-a2a";
+    std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    try std_compat.fs.makeDirAbsolute(tmp_dir);
+    defer std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.json", .{tmp_dir});
+    defer allocator.free(config_path);
+
+    // Simulate the config that --from-json generates: a2a.enabled = false.
+    const initial = "{\"a2a\":{\"enabled\":false,\"url\":\"\"},\"models\":{\"providers\":{}}}";
+    try writeFile(config_path, initial);
+
+    try patchProviderIntoConfig(allocator, config_path, "myprovider", "sk-test", "", "gpt-4o");
+
+    const file = try std_compat.fs.openFileAbsolute(config_path, .{});
+    defer file.close();
+    const contents = try file.readToEndAlloc(allocator, 64 * 1024);
+    defer allocator.free(contents);
+
+    // a2a.enabled must be patched to true.
+    try std.testing.expect(std.mem.indexOf(u8, contents, "\"enabled\": true") != null);
+    // Provider and api_key must be written.
+    try std.testing.expect(std.mem.indexOf(u8, contents, "\"myprovider\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, contents, "\"sk-test\"") != null);
+}
+
+test "patchProviderIntoConfig leaves a2a.enabled true unchanged" {
+    const allocator = std.testing.allocator;
+    const tmp_dir = "/tmp/test-patch-a2a-true";
+    std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    try std_compat.fs.makeDirAbsolute(tmp_dir);
+    defer std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+
+    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.json", .{tmp_dir});
+    defer allocator.free(config_path);
+
+    const initial = "{\"a2a\":{\"enabled\":true,\"url\":\"http://127.0.0.1:5111\"},\"models\":{\"providers\":{}}}";
+    try writeFile(config_path, initial);
+
+    try patchProviderIntoConfig(allocator, config_path, "myprovider", "sk-test", "", "gpt-4o");
+
+    const file = try std_compat.fs.openFileAbsolute(config_path, .{});
+    defer file.close();
+    const contents = try file.readToEndAlloc(allocator, 64 * 1024);
+    defer allocator.free(contents);
+
+    // enabled stays true, url is preserved.
+    try std.testing.expect(std.mem.indexOf(u8, contents, "\"enabled\": true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, contents, "http://127.0.0.1:5111") != null);
 }

--- a/src/installer/orchestrator.zig
+++ b/src/installer/orchestrator.zig
@@ -210,7 +210,13 @@ pub fn install(
     // If the primary provider is openai-compatible (has a base_url), strip it from the answers
     // before passing to the binary — the binary only knows standard provider names.  We will
     // inject the custom provider credentials into the generated config afterwards.
-    const custom_provider_result = extractCustomProvider(allocator, opts.answers_json) catch null;
+    const custom_provider_result = extractCustomProvider(allocator, opts.answers_json) catch |err| blk: {
+        std.debug.print("[orchestrator] extractCustomProvider error: {s}\n", .{@errorName(err)});
+        break :blk null;
+    };
+    if (custom_provider_result == null) {
+        std.debug.print("[orchestrator] no custom provider detected in answers\n", .{});
+    }
     defer if (custom_provider_result) |cp| {
         allocator.free(cp.custom.provider);
         allocator.free(cp.custom.api_key);
@@ -621,13 +627,31 @@ fn extractCustomProvider(allocator: std.mem.Allocator, json: []const u8) !?struc
         .base_url = try allocator.dupe(u8, base_url),
     };
 
-    // Clear the provider-specific fields so the binary receives no provider.
-    try root.put(allocator, "provider", .{ .string = "" });
+    // Replace provider-specific fields with a known standard provider so the
+    // binary generates a valid base config without failing on the custom name.
+    // The real credentials are injected into the config file after the binary runs.
+    try root.put(allocator, "provider", .{ .string = "openai" });
     try root.put(allocator, "api_key", .{ .string = "" });
     try root.put(allocator, "model", .{ .string = "" });
     try root.put(allocator, "base_url", .{ .string = "" });
 
+    // Also neutralise the `providers` array that the wizard sends alongside the
+    // top-level fields — nullclaw reads from both, and leaving the custom name
+    // in the array is what caused "UNKNOWN PROVIDER '<name>'" errors.
+    if (root.getPtr("providers")) |arr_val| {
+        if (arr_val.* == .array) {
+            for (arr_val.array.items) |*item| {
+                if (item.* != .object) continue;
+                try item.object.put(allocator, "provider", .{ .string = "openai" });
+                try item.object.put(allocator, "api_key", .{ .string = "" });
+                try item.object.put(allocator, "model", .{ .string = "" });
+                try item.object.put(allocator, "base_url", .{ .string = "" });
+            }
+        }
+    }
+
     const stripped = try std.json.Stringify.valueAlloc(allocator, parsed.value, .{});
+    std.debug.print("[orchestrator] custom provider '{s}' detected; stripped answers: {s}\n", .{ cp.provider, stripped });
     return .{ .custom = cp, .stripped_json = stripped };
 }
 

--- a/src/installer/orchestrator.zig
+++ b/src/installer/orchestrator.zig
@@ -211,12 +211,9 @@ pub fn install(
     // before passing to the binary — the binary only knows standard provider names.  We will
     // inject the custom provider credentials into the generated config afterwards.
     const custom_provider_result = extractCustomProvider(allocator, opts.answers_json) catch |err| blk: {
-        std.debug.print("[orchestrator] extractCustomProvider error: {s}\n", .{@errorName(err)});
+        std.log.warn("extractCustomProvider failed: {s}", .{@errorName(err)});
         break :blk null;
     };
-    if (custom_provider_result == null) {
-        std.debug.print("[orchestrator] no custom provider detected in answers\n", .{});
-    }
     defer if (custom_provider_result) |cp| {
         allocator.free(cp.custom.provider);
         allocator.free(cp.custom.api_key);
@@ -260,7 +257,7 @@ pub fn install(
         defer if (config_path) |path| allocator.free(path);
         if (config_path) |path| {
             patchProviderIntoConfig(allocator, path, cp.custom.provider, cp.custom.api_key, cp.custom.base_url, cp.custom.model) catch |err| {
-                std.debug.print("warning: failed to inject custom provider into config: {s}\n", .{@errorName(err)});
+                std.log.warn("failed to inject custom provider into config: {s}", .{@errorName(err)});
             };
         }
     }
@@ -658,7 +655,6 @@ fn extractCustomProvider(allocator: std.mem.Allocator, json: []const u8) !?struc
     }
 
     const stripped = try std.json.Stringify.valueAlloc(allocator, parsed.value, .{});
-    std.debug.print("[orchestrator] custom provider '{s}' detected; stripped answers: {s}\n", .{ cp.provider, stripped });
     return .{ .custom = cp, .stripped_json = stripped };
 }
 

--- a/src/installer/orchestrator.zig
+++ b/src/installer/orchestrator.zig
@@ -693,20 +693,6 @@ fn patchProviderIntoConfig(
     if (parsed.value != .object) return error.InvalidConfig;
     const root = &parsed.value.object;
 
-    // The nullclaw-dev-local binary panics with "programmer bug caused syscall
-    // error: AGAIN" when a2a.enabled is false.  The --from-json generator
-    // always emits enabled:false for fresh installs, so patch it to true here.
-    // Leave all other a2a fields (name, description, url, version) as-is.
-    if (root.getPtr("a2a")) |a2a_val| {
-        if (a2a_val.* == .object) {
-            if (a2a_val.object.getPtr("enabled")) |enabled_val| {
-                if (enabled_val.* == .bool and !enabled_val.bool) {
-                    enabled_val.* = .{ .bool = true };
-                }
-            }
-        }
-    }
-
     const models_obj = try ensureObjectInMap(ja, root, "models");
     const providers_obj = try ensureObjectInMap(ja, models_obj, "providers");
     const provider_obj = try ensureObjectInMap(ja, providers_obj, provider);
@@ -1236,57 +1222,4 @@ test "injectHomeField adds home to JSON object" {
     defer allocator.free(result);
     try std.testing.expect(std.mem.indexOf(u8, result, "\"home\":\"/tmp/inst\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, result, "\"provider\":\"openrouter\"") != null);
-}
-
-test "patchProviderIntoConfig fixes a2a.enabled false to true" {
-    const allocator = std.testing.allocator;
-    const tmp_dir = "/tmp/test-patch-a2a";
-    std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
-    try std_compat.fs.makeDirAbsolute(tmp_dir);
-    defer std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
-
-    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.json", .{tmp_dir});
-    defer allocator.free(config_path);
-
-    // Simulate the config that --from-json generates: a2a.enabled = false.
-    const initial = "{\"a2a\":{\"enabled\":false,\"url\":\"\"},\"models\":{\"providers\":{}}}";
-    try writeFile(config_path, initial);
-
-    try patchProviderIntoConfig(allocator, config_path, "myprovider", "sk-test", "", "gpt-4o");
-
-    const file = try std_compat.fs.openFileAbsolute(config_path, .{});
-    defer file.close();
-    const contents = try file.readToEndAlloc(allocator, 64 * 1024);
-    defer allocator.free(contents);
-
-    // a2a.enabled must be patched to true.
-    try std.testing.expect(std.mem.indexOf(u8, contents, "\"enabled\": true") != null);
-    // Provider and api_key must be written.
-    try std.testing.expect(std.mem.indexOf(u8, contents, "\"myprovider\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, contents, "\"sk-test\"") != null);
-}
-
-test "patchProviderIntoConfig leaves a2a.enabled true unchanged" {
-    const allocator = std.testing.allocator;
-    const tmp_dir = "/tmp/test-patch-a2a-true";
-    std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
-    try std_compat.fs.makeDirAbsolute(tmp_dir);
-    defer std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
-
-    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.json", .{tmp_dir});
-    defer allocator.free(config_path);
-
-    const initial = "{\"a2a\":{\"enabled\":true,\"url\":\"http://127.0.0.1:5111\"},\"models\":{\"providers\":{}}}";
-    try writeFile(config_path, initial);
-
-    try patchProviderIntoConfig(allocator, config_path, "myprovider", "sk-test", "", "gpt-4o");
-
-    const file = try std_compat.fs.openFileAbsolute(config_path, .{});
-    defer file.close();
-    const contents = try file.readToEndAlloc(allocator, 64 * 1024);
-    defer allocator.free(contents);
-
-    // enabled stays true, url is preserved.
-    try std.testing.expect(std.mem.indexOf(u8, contents, "\"enabled\": true") != null);
-    try std.testing.expect(std.mem.indexOf(u8, contents, "http://127.0.0.1:5111") != null);
 }

--- a/src/server.zig
+++ b/src/server.zig
@@ -919,6 +919,18 @@ pub const Server = struct {
                 }
                 return .{ .status = "405 Method Not Allowed", .content_type = "application/json", .body = "{\"error\":\"method not allowed\"}" };
             }
+            // GET /api/providers/probe-models — probe a custom endpoint before saving
+            if (providers_api.isProbeModelsPath(target)) {
+                if (std.mem.eql(u8, method, "GET")) {
+                    if (providers_api.handleProbeModels(allocator, target)) |json| {
+                        const status = if (std.mem.indexOf(u8, json, "\"error\"") != null) "400 Bad Request" else "200 OK";
+                        return .{ .status = status, .content_type = "application/json", .body = json };
+                    } else |_| {
+                        return .{ .status = "500 Internal Server Error", .content_type = "application/json", .body = "{\"error\":\"internal error\"}" };
+                    }
+                }
+                return .{ .status = "405 Method Not Allowed", .content_type = "application/json", .body = "{\"error\":\"method not allowed\"}" };
+            }
             // Routes with ID: /api/providers/{id} and /api/providers/{id}/validate
             if (providers_api.extractProviderId(target)) |id| {
                 if (providers_api.isValidatePath(target)) {

--- a/src/server.zig
+++ b/src/server.zig
@@ -922,10 +922,18 @@ pub const Server = struct {
                 }
                 return .{ .status = "405 Method Not Allowed", .content_type = "application/json", .body = "{\"error\":\"method not allowed\"}" };
             }
-            // GET /api/providers/probe-models — probe a custom endpoint before saving
+            // /api/providers/probe-models — probe a custom endpoint before saving
             if (providers_api.isProbeModelsPath(target)) {
                 if (std.mem.eql(u8, method, "GET")) {
                     if (providers_api.handleProbeModels(allocator, target)) |json| {
+                        const status = if (std.mem.indexOf(u8, json, "\"error\"") != null) "400 Bad Request" else "200 OK";
+                        return .{ .status = status, .content_type = "application/json", .body = json };
+                    } else |_| {
+                        return .{ .status = "500 Internal Server Error", .content_type = "application/json", .body = "{\"error\":\"internal error\"}" };
+                    }
+                }
+                if (std.mem.eql(u8, method, "POST")) {
+                    if (providers_api.handleProbeModelsBody(allocator, body)) |json| {
                         const status = if (std.mem.indexOf(u8, json, "\"error\"") != null) "400 Bad Request" else "200 OK";
                         return .{ .status = status, .content_type = "application/json", .body = json };
                     } else |_| {

--- a/src/server.zig
+++ b/src/server.zig
@@ -55,7 +55,10 @@ pub const Server = struct {
         defer allocator.free(state_path);
 
         const state = try allocator.create(state_mod.State);
-        state.* = state_mod.State.load(allocator, state_path) catch state_mod.State.init(allocator, state_path);
+        state.* = state_mod.State.load(allocator, state_path) catch |err| blk: {
+            std.log.err("state.json load failed ({s}): starting with empty state — YOUR DATA MAY BE AT RISK", .{@errorName(err)});
+            break :blk state_mod.State.init(allocator, state_path);
+        };
 
         orchestrator.syncLocalUiModules(allocator, paths);
 

--- a/ui/src/lib/api/client.ts
+++ b/ui/src/lib/api/client.ts
@@ -199,10 +199,11 @@ export const api = {
     request<any>(`/providers/${id.replace('sp_', '')}`, { method: 'DELETE' }),
   revalidateSavedProvider: (id: string) =>
     request<any>(`/providers/${id.replace('sp_', '')}/validate`, { method: 'POST' }),
-  probeProviderModels: (baseUrl: string, apiKey: string) => {
-    const params = new URLSearchParams({ base_url: baseUrl, api_key: apiKey });
-    return request<{ live_ok: boolean; reason: string; models: string[] }>(`/providers/probe-models?${params}`);
-  },
+  probeProviderModels: (baseUrl: string, apiKey: string) =>
+    request<{ live_ok: boolean; reason: string; models: string[] }>('/providers/probe-models', {
+      method: 'POST',
+      body: JSON.stringify({ base_url: baseUrl, api_key: apiKey }),
+    }),
 
   // Saved channels
   getSavedChannels: (reveal = false) =>

--- a/ui/src/lib/api/client.ts
+++ b/ui/src/lib/api/client.ts
@@ -199,6 +199,10 @@ export const api = {
     request<any>(`/providers/${id.replace('sp_', '')}`, { method: 'DELETE' }),
   revalidateSavedProvider: (id: string) =>
     request<any>(`/providers/${id.replace('sp_', '')}/validate`, { method: 'POST' }),
+  probeProviderModels: (baseUrl: string, apiKey: string) => {
+    const params = new URLSearchParams({ base_url: baseUrl, api_key: apiKey });
+    return request<{ live_ok: boolean; reason: string; models: string[] }>(`/providers/probe-models?${params}`);
+  },
 
   // Saved channels
   getSavedChannels: (reveal = false) =>

--- a/ui/src/lib/components/ProviderList.svelte
+++ b/ui/src/lib/components/ProviderList.svelte
@@ -40,8 +40,10 @@
 
   onMount(async () => {
     try {
-      const data = await api.getSavedProviders();
+      // Fetch revealed keys upfront so the "Use Saved" dropdown is instant on click.
+      const data = await api.getSavedProviders(true);
       savedProviders = data.providers || [];
+      savedProvidersRevealed = true;
     } catch {}
   });
 

--- a/ui/src/lib/components/ProviderList.svelte
+++ b/ui/src/lib/components/ProviderList.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
   import { api } from "$lib/api/client";
+  import { OPENAI_COMPATIBLE_VALUE, LOCAL_PROVIDERS, mergeWithManifestOptions } from "$lib/providers";
+  import type { ProviderOption } from "$lib/providers";
 
   let {
     providers = [],
@@ -10,15 +12,11 @@
     validationResults = [] as Array<{ provider: string; live_ok: boolean; reason: string }>,
   } = $props();
 
-  const LOCAL_PROVIDERS = ["ollama", "lm-studio", "claude-cli", "codex-cli", "openai-codex"];
   const MODEL_RESULTS_LIMIT = 80;
-  const OPENAI_COMPATIBLE_VALUE = "openai-compatible";
 
-  type ProviderOption = {
-    value: string;
-    label: string;
-    recommended?: boolean;
-  };
+  // Merge the canonical list with whatever the manifest marks as recommended.
+  // This ensures openai-compatible always appears regardless of the manifest.
+  const effectiveProviders: ProviderOption[] = $derived(mergeWithManifestOptions(providers));
 
   type ProviderEntry = {
     provider: string;
@@ -120,8 +118,8 @@
 
   function addEntry() {
     // Find recommended provider or first available
-    const rec = providers.find((p: any) => p.recommended);
-    const defaultProvider = rec?.value || providers[0]?.value || "";
+    const rec = effectiveProviders.find((p: any) => p.recommended);
+    const defaultProvider = rec?.value || effectiveProviders[0]?.value || "";
     entries = [
       ...entries,
       { provider: defaultProvider, api_key: "", model: "", base_url: "", provider_name: "" },
@@ -334,7 +332,7 @@
           value={entry.provider}
           onchange={(e) => updateEntry(i, "provider", e.currentTarget.value)}
         >
-          {#each providers as opt}
+          {#each effectiveProviders as opt}
             <option value={opt.value}
               >{formatRecommendedLabel(opt.label, opt.recommended)}</option
             >

--- a/ui/src/lib/components/ProviderList.svelte
+++ b/ui/src/lib/components/ProviderList.svelte
@@ -187,7 +187,7 @@
   }
 
   function modelKey(entry: ProviderEntry) {
-    return `${entry.provider}\u0000${entry.api_key}`;
+    return `${entry.provider}\u0000${entry.api_key}\u0000${entry.base_url}`;
   }
 
   function getModelOptions(entry: ProviderEntry) {
@@ -203,7 +203,11 @@
   }
 
   async function ensureModelOptions(entry: ProviderEntry) {
-    if (!component || !entry.provider) return;
+    if (!entry.provider) return;
+    // openai-compatible requires a base_url to probe — skip until one is entered
+    if (entry.provider === OPENAI_COMPATIBLE_VALUE && !entry.base_url) return;
+    // standard providers require a component (binary) to list models
+    if (entry.provider !== OPENAI_COMPATIBLE_VALUE && !component) return;
 
     const key = modelKey(entry);
     if (modelLoadingByKey[key] || modelLoadedByKey[key]) return;
@@ -212,12 +216,19 @@
     modelErrorsByKey = { ...modelErrorsByKey, [key]: "" };
 
     try {
-      const data = await api.getWizardModels(component, entry.provider, entry.api_key || "");
-      const models = Array.isArray(data)
-        ? data
-        : Array.isArray(data?.models)
-          ? data.models
-          : [];
+      let models: string[];
+      if (entry.provider === OPENAI_COMPATIBLE_VALUE && entry.base_url) {
+        // Custom OpenAI-compatible: probe the /models endpoint directly
+        const data = await api.probeProviderModels(entry.base_url, entry.api_key || "");
+        models = data.live_ok && Array.isArray(data.models) ? data.models : [];
+      } else {
+        const data = await api.getWizardModels(component, entry.provider, entry.api_key || "");
+        models = Array.isArray(data)
+          ? data
+          : Array.isArray(data?.models)
+            ? data.models
+            : [];
+      }
       const normalized = models.filter((model): model is string => typeof model === "string");
       modelOptionsByKey = { ...modelOptionsByKey, [key]: normalized };
       modelLoadedByKey = { ...modelLoadedByKey, [key]: true };

--- a/ui/src/lib/components/WizardRenderer.svelte
+++ b/ui/src/lib/components/WizardRenderer.svelte
@@ -297,7 +297,7 @@
           let parsed = JSON.parse(_providers);
           // Transform openai-compatible entries: use provider_name as the actual provider
           parsed = parsed.map((entry: any) => {
-            if (entry.provider === "openai-compatible") {
+            if (entry.provider === OPENAI_COMPATIBLE_VALUE) {
               const { provider_name, ...rest } = entry;
               return { ...rest, provider: provider_name || entry.provider };
             }

--- a/ui/src/lib/components/WizardRenderer.svelte
+++ b/ui/src/lib/components/WizardRenderer.svelte
@@ -194,11 +194,21 @@
       const standardBatch: any[] = [];
 
       for (const p of rawProviders) {
-        if (p.provider === OPENAI_COMPATIBLE_VALUE && p.base_url) {
+        if (p.provider === OPENAI_COMPATIBLE_VALUE) {
+          const providerName = String(p.provider_name || "").trim();
+          const baseUrl = String(p.base_url || "").trim();
+          if (!providerName) {
+            allResults.push({ provider: p.provider, live_ok: false, reason: "missing_provider_name" });
+            continue;
+          }
+          if (!baseUrl) {
+            allResults.push({ provider: p.provider, live_ok: false, reason: "missing_base_url" });
+            continue;
+          }
           // Custom OpenAI-compatible endpoint: validate via HTTP probe, not the nullclaw binary.
           // The binary doesn't know the "openai-compatible" provider name.
           try {
-            const probe = await api.probeProviderModels(p.base_url, p.api_key || "");
+            const probe = await api.probeProviderModels(baseUrl, p.api_key || "");
             allResults.push({ provider: p.provider, live_ok: probe.live_ok, reason: probe.reason || "" });
           } catch {
             allResults.push({ provider: p.provider, live_ok: false, reason: "probe_request_failed" });
@@ -299,7 +309,7 @@
           parsed = parsed.map((entry: any) => {
             if (entry.provider === OPENAI_COMPATIBLE_VALUE) {
               const { provider_name, ...rest } = entry;
-              return { ...rest, provider: provider_name || entry.provider };
+              return { ...rest, provider: String(provider_name || "").trim() };
             }
             return entry;
           });

--- a/ui/src/lib/components/WizardRenderer.svelte
+++ b/ui/src/lib/components/WizardRenderer.svelte
@@ -3,6 +3,7 @@
   import ProviderList from "./ProviderList.svelte";
   import ChannelList from "./ChannelList.svelte";
   import { api } from "$lib/api/client";
+  import { OPENAI_COMPATIBLE_VALUE } from "$lib/providers";
 
   let {
     component = "",
@@ -183,15 +184,38 @@
     providerValidationResults = [];
 
     try {
-      const providers = JSON.parse(answers["_providers"] || "[]");
-      if (providers.length === 0) {
+      const rawProviders: any[] = JSON.parse(answers["_providers"] || "[]");
+      if (rawProviders.length === 0) {
         validationError = "Add at least one provider";
         return false;
       }
-      const result = await api.validateProviders(component, providers);
-      providerValidationResults = result.results || [];
-      validationWarning = result.saved_providers_warning || "";
-      return providerValidationResults.every((r: any) => r.live_ok);
+
+      const allResults: Array<{ provider: string; live_ok: boolean; reason: string }> = [];
+      const standardBatch: any[] = [];
+
+      for (const p of rawProviders) {
+        if (p.provider === OPENAI_COMPATIBLE_VALUE && p.base_url) {
+          // Custom OpenAI-compatible endpoint: validate via HTTP probe, not the nullclaw binary.
+          // The binary doesn't know the "openai-compatible" provider name.
+          try {
+            const probe = await api.probeProviderModels(p.base_url, p.api_key || "");
+            allResults.push({ provider: p.provider, live_ok: probe.live_ok, reason: probe.reason || "" });
+          } catch {
+            allResults.push({ provider: p.provider, live_ok: false, reason: "probe_request_failed" });
+          }
+        } else {
+          standardBatch.push(p);
+        }
+      }
+
+      if (standardBatch.length > 0) {
+        const batchResult = await api.validateProviders(component, standardBatch);
+        allResults.push(...(batchResult.results || []));
+        if (batchResult.saved_providers_warning) validationWarning = batchResult.saved_providers_warning;
+      }
+
+      providerValidationResults = allResults;
+      return allResults.every((r) => r.live_ok);
     } catch (e) {
       validationError = `Validation failed: ${(e as Error).message}`;
       return false;

--- a/ui/src/lib/providers.ts
+++ b/ui/src/lib/providers.ts
@@ -1,0 +1,57 @@
+export type ProviderOption = {
+  value: string;
+  label: string;
+  recommended?: boolean;
+};
+
+/**
+ * Canonical list of providers known to NullHub.
+ * Both the Providers management page and the wizard's ProviderList component
+ * must derive their dropdowns from this single source of truth.
+ */
+export const PROVIDER_OPTIONS: ProviderOption[] = [
+  { value: "openrouter", label: "OpenRouter (multi-provider, recommended)", recommended: true },
+  { value: "anthropic", label: "Anthropic" },
+  { value: "openai", label: "OpenAI" },
+  { value: "google", label: "Google AI" },
+  { value: "mistral", label: "Mistral" },
+  { value: "groq", label: "Groq" },
+  { value: "deepseek", label: "DeepSeek" },
+  { value: "cohere", label: "Cohere" },
+  { value: "together", label: "Together AI" },
+  { value: "fireworks", label: "Fireworks AI" },
+  { value: "perplexity", label: "Perplexity" },
+  { value: "xai", label: "xAI" },
+  { value: "ollama", label: "Ollama (local)" },
+  { value: "lm-studio", label: "LM Studio (local)" },
+  { value: "claude-cli", label: "Claude CLI (local)" },
+  { value: "codex-cli", label: "Codex CLI (local CLI)" },
+  { value: "openai-codex", label: "OpenAI Codex (ChatGPT login)" },
+  { value: "openai-compatible", label: "OpenAI Compatible (custom endpoint)" },
+];
+
+export const OPENAI_COMPATIBLE_VALUE = "openai-compatible";
+
+export const LOCAL_PROVIDERS = ["ollama", "lm-studio", "claude-cli", "codex-cli", "openai-codex"];
+
+/**
+ * Set of all provider values that are NOT the openai-compatible catch-all.
+ * Used to determine whether a saved provider entry is a named standard provider
+ * or a custom/self-hosted endpoint.
+ */
+export const KNOWN_PROVIDER_VALUES = new Set(
+  PROVIDER_OPTIONS.filter((o) => o.value !== OPENAI_COMPATIBLE_VALUE).map((o) => o.value),
+);
+
+/**
+ * Merge the canonical provider list with manifest-provided options.
+ * The manifest may mark a specific provider as `recommended`; that flag wins
+ * over the default. All canonical options (including openai-compatible) are
+ * always present regardless of what the manifest returns.
+ */
+export function mergeWithManifestOptions(manifestOptions: ProviderOption[]): ProviderOption[] {
+  return PROVIDER_OPTIONS.map((opt) => {
+    const fromManifest = manifestOptions.find((m) => m.value === opt.value);
+    return fromManifest ? { ...opt, recommended: fromManifest.recommended ?? opt.recommended } : opt;
+  });
+}

--- a/ui/src/routes/instances/[component]/[name]/+page.svelte
+++ b/ui/src/routes/instances/[component]/[name]/+page.svelte
@@ -53,10 +53,18 @@
       (providerHealthCurrent ? Boolean(providerHealthCurrent.live_ok) : providerStatus.configured),
   );
   let providerCardWarn = $derived(
-    providerHealthCurrent ? !providerDotOk : !providerStatus.configured,
+    instance?.status === "running"
+      ? (providerHealthCurrent ? !providerDotOk : !providerStatus.configured)
+      : !providerStatus.configured,
   );
   let providerHintText = $derived(
-    buildProviderHint(providerStatus, providerHealthCurrent, providerHealthLoading),
+    buildProviderHint(
+      providerStatus,
+      // Only surface live-probe errors when the instance is actually running —
+      // otherwise the result is stale/irrelevant (probe ran while starting).
+      instance?.status === "running" ? providerHealthCurrent : null,
+      providerHealthLoading,
+    ),
   );
   let chatModuleName = $derived(
     uiModules["nullclaw-chat-ui"] ? "nullclaw-chat-ui" : "",
@@ -483,6 +491,7 @@
   }
 
   async function refresh(loadProviderHealth = false, forceUsage = false) {
+    const prevStatus = instance?.status;
     try {
       const status = await api.getStatus();
       const instances = status.instances || {};
@@ -492,6 +501,8 @@
     } catch (e) {
       console.error(e);
     }
+    // Re-fetch provider health when the instance just became running (stale probe from boot)
+    const justBecameRunning = instance?.status === "running" && prevStatus !== "running";
     // Fetch config (best-effort)
     let loadedConfig: any = null;
     try {
@@ -510,7 +521,7 @@
     } else {
       onboardingStatus = null;
     }
-    if (loadProviderHealth) {
+    if (loadProviderHealth || justBecameRunning) {
       await refreshProviderHealth(loadedConfig);
     }
     await refreshUsage(forceUsage);

--- a/ui/src/routes/providers/+page.svelte
+++ b/ui/src/routes/providers/+page.svelte
@@ -24,6 +24,9 @@
   ];
   const LOCAL_PROVIDERS = ["ollama", "lm-studio", "claude-cli", "codex-cli", "openai-codex"];
   const OPENAI_COMPATIBLE_VALUE = "openai-compatible";
+  const KNOWN_PROVIDER_VALUES = new Set(
+    PROVIDER_OPTIONS.filter(o => o.value !== OPENAI_COMPATIBLE_VALUE).map(o => o.value)
+  );
 
   let providers = $state<any[]>([]);
   let loading = $state(true);
@@ -44,6 +47,7 @@
   // Edit state
   let editingId = $state<string | null>(null);
   let editForm = $state({ name: "", api_key: "", model: "", base_url: "" });
+  let editRealApiKey = $state(""); // revealed key fetched on edit open; used by Fetch Models when form field is blank
   let editValidating = $state(false);
   let editError = $state("");
   let editProbing = $state(false);
@@ -113,9 +117,9 @@
     editProbing = true;
     editProbeError = "";
     editProbedModels = [];
-    const key = editForm.api_key.trim() || "(current key)";
     try {
-      const result = await api.probeProviderModels(editForm.base_url.trim(), editForm.api_key.trim() || key);
+      const keyToUse = editForm.api_key.trim() || editRealApiKey;
+      const result = await api.probeProviderModels(editForm.base_url.trim(), keyToUse);
       if (result.live_ok) {
         editProbedModels = result.models;
         if (!editProbedModels.length) editProbeError = "Connected, but no models returned.";
@@ -168,8 +172,14 @@
   function startEdit(p: any) {
     editingId = p.id;
     editForm = { name: p.name, api_key: "", model: p.model, base_url: p.base_url || "" };
+    editRealApiKey = "";
     editProbedModels = [];
     editProbeError = "";
+    // Fetch the real (revealed) key so Fetch Models works without the user re-entering the key
+    api.getSavedProviders(true).then(data => {
+      const found = (data.providers || []).find((x: any) => x.id === p.id);
+      if (found) editRealApiKey = found.api_key || "";
+    }).catch(() => {});
   }
 
   function cancelEdit() {
@@ -224,8 +234,10 @@
     return LOCAL_PROVIDERS.includes(provider);
   }
 
-  function isOpenAiCompatible(p: any) {
-    return p.base_url && p.base_url.length > 0;
+  // A provider is "custom" if its type is not one of the built-in nullclaw-known providers.
+  // This determines whether the base_url / Fetch Models fields appear in edit form.
+  function isCustomProvider(p: any) {
+    return !KNOWN_PROVIDER_VALUES.has(p.provider);
   }
 
   function getProviderLabel(value: string) {
@@ -371,7 +383,7 @@
                 <label for="edit-name-{p.id}">Name</label>
                 <input id="edit-name-{p.id}" type="text" bind:value={editForm.name} />
               </div>
-              {#if isOpenAiCompatible(p)}
+              {#if isCustomProvider(p)}
                 <div class="field">
                   <label for="edit-base-url-{p.id}">Base URL</label>
                   <input id="edit-base-url-{p.id}" type="text" bind:value={editForm.base_url} placeholder="https://api.example.com/v1" />
@@ -385,7 +397,7 @@
               {/if}
               <div class="field">
                 <label for="edit-model-{p.id}">Model</label>
-                {#if isOpenAiCompatible(p)}
+                {#if isCustomProvider(p)}
                   <div class="model-input-row">
                     <input id="edit-model-{p.id}" type="text" bind:value={editForm.model} placeholder="e.g. gpt-4" />
                     <button
@@ -414,348 +426,6 @@
                 {:else}
                   <input id="edit-model-{p.id}" type="text" bind:value={editForm.model} placeholder="e.g. anthropic/claude-sonnet-4" />
                 {/if}
-              </div>
-              {#if editError}
-                <div class="error-message">{editError}</div>
-              {/if}
-              <div class="edit-actions">
-                <button class="primary-btn" onclick={() => saveEdit(p.id)} disabled={editValidating}>
-                  {editValidating ? "Saving..." : "Save"}
-                </button>
-                <button class="btn" onclick={cancelEdit}>Cancel</button>
-              </div>
-            </div>
-          {:else}
-            {@const indicator = providerIndicatorState(p)}
-            <div class="card-header">
-              <div class="card-title">
-                <span
-                  class="status-dot"
-                  class:live-ok={indicator === "live-ok"}
-                  class:live-error={indicator === "live-error"}
-                  class:has-history={indicator === "has-history"}
-                  class:needs-validation={indicator === "needs-validation"}
-                ></span>
-                <h3>{p.name}</h3>
-              </div>
-              <span class="provider-type">{getProviderLabel(p.provider)}</span>
-            </div>
-            <div class="card-body">
-              <div class="card-field">
-                <span class="label">API Key</span>
-                <code>{p.api_key}</code>
-              </div>
-              {#if p.base_url}
-                <div class="card-field">
-                  <span class="label">Base URL</span>
-                  <code>{p.base_url}</code>
-                </div>
-              {/if}
-              <div class="card-field">
-                <span class="label">Model</span>
-                <code>{p.model || "No default model"}</code>
-              </div>
-              {#if p.validated_at}
-                <div class="card-field">
-                  <span class="label">Last Successful Validation</span>
-                  <span>{formatDate(p.validated_at)}</span>
-                </div>
-              {/if}
-              <div class="card-field">
-                <span class="label">Last Validation</span>
-                <span>{formatDate(lastValidationAt(p)) || "Never"}</span>
-              </div>
-              {#if !lastValidationAt(p)}
-                <div class="card-note">Not validated yet. Use Re-validate to run a live auth check.</div>
-              {/if}
-            </div>
-            <div class="card-actions">
-              <button class="btn" onclick={() => handleRevalidate(p.id)} disabled={revalidatingId === p.id}>
-                {revalidatingId === p.id ? "Validating..." : "Re-validate"}
-              </button>
-              <button class="btn" onclick={() => startEdit(p)}>Edit</button>
-              <button class="btn danger" onclick={() => handleDelete(p.id)}>Delete</button>
-            </div>
-          {/if}
-        </div>
-      {/each}
-    </div>
-  {/if}
-</div>
-
-  let providers = $state<any[]>([]);
-  let loading = $state(true);
-  let error = $state("");
-  let message = $state("");
-  let messageTone = $state<"success" | "error">("success");
-  let messageTimer: ReturnType<typeof setTimeout> | null = null;
-
-  // Add form state
-  let showAddForm = $state(false);
-  let addForm = $state({ provider: "openrouter", provider_name: "", api_key: "", model: "", base_url: "" });
-  let addValidating = $state(false);
-  let addError = $state("");
-
-  // Edit state
-  let editingId = $state<string | null>(null);
-  let editForm = $state({ name: "", api_key: "", model: "", base_url: "" });
-  let editValidating = $state(false);
-  let editError = $state("");
-
-  // Re-validate state
-  let revalidatingId = $state<string | null>(null);
-
-  let hasComponents = $state(false);
-
-  onMount(async () => {
-    await loadProviders();
-    try {
-      const status = await api.getStatus();
-      hasComponents = Object.keys(status.instances || {}).length > 0;
-    } catch {}
-  });
-
-  onDestroy(() => {
-    if (messageTimer) clearTimeout(messageTimer);
-  });
-
-  function flashMessage(text: string, tone: "success" | "error" = "success", timeoutMs = 3000) {
-    message = text;
-    messageTone = tone;
-    if (messageTimer) clearTimeout(messageTimer);
-    messageTimer = setTimeout(() => {
-      message = "";
-      messageTimer = null;
-    }, timeoutMs);
-  }
-
-  async function loadProviders() {
-    loading = true;
-    error = "";
-    try {
-      const data = await api.getSavedProviders();
-      providers = data.providers || [];
-    } catch (e) {
-      error = (e as Error).message;
-    } finally {
-      loading = false;
-    }
-  }
-
-  async function handleAdd() {
-    addValidating = true;
-    addError = "";
-    try {
-      const providerValue = addForm.provider === OPENAI_COMPATIBLE_VALUE
-        ? addForm.provider_name.trim()
-        : addForm.provider;
-      if (addForm.provider === OPENAI_COMPATIBLE_VALUE && !providerValue) {
-        addError = "Provider name is required for OpenAI Compatible providers.";
-        addValidating = false;
-        return;
-      }
-      if (addForm.provider === OPENAI_COMPATIBLE_VALUE && !addForm.base_url.trim()) {
-        addError = "Base URL is required for OpenAI Compatible providers.";
-        addValidating = false;
-        return;
-      }
-      await api.createSavedProvider({
-        provider: providerValue,
-        api_key: addForm.api_key,
-        model: addForm.model || undefined,
-        base_url: addForm.base_url || undefined,
-      });
-      showAddForm = false;
-      addForm = { provider: "openrouter", provider_name: "", api_key: "", model: "", base_url: "" };
-      flashMessage("Provider saved");
-      await loadProviders();
-    } catch (e) {
-      addError = (e as Error).message;
-    } finally {
-      addValidating = false;
-    }
-  }
-
-  function startEdit(p: any) {
-    editingId = p.id;
-    editForm = { name: p.name, api_key: "", model: p.model, base_url: p.base_url || "" };
-  }
-
-  function cancelEdit() {
-    editingId = null;
-  }
-
-  async function saveEdit(id: string) {
-    editValidating = true;
-    editError = "";
-    try {
-      const payload: any = {};
-      if (editForm.name) payload.name = editForm.name;
-      if (editForm.api_key) payload.api_key = editForm.api_key;
-      payload.model = editForm.model;
-      payload.base_url = editForm.base_url;
-      await api.updateSavedProvider(id, payload);
-      editingId = null;
-      flashMessage("Provider updated");
-      await loadProviders();
-    } catch (e) {
-      editError = (e as Error).message;
-      await loadProviders();
-    } finally {
-      editValidating = false;
-    }
-  }
-
-  async function handleDelete(id: string) {
-    try {
-      await api.deleteSavedProvider(id);
-      flashMessage("Provider deleted");
-      await loadProviders();
-    } catch (e) {
-      error = (e as Error).message;
-    }
-  }
-
-  async function handleRevalidate(id: string) {
-    revalidatingId = id;
-    try {
-      await api.revalidateSavedProvider(id);
-      flashMessage("Validation passed", "success", 5000);
-    } catch (e) {
-      flashMessage(`Validation failed: ${(e as Error).message}`, "error", 5000);
-    } finally {
-      await loadProviders();
-      revalidatingId = null;
-    }
-  }
-
-  function isLocal(provider: string) {
-    return LOCAL_PROVIDERS.includes(provider);
-  }
-
-  function isOpenAiCompatible(p: any) {
-    return p.base_url && p.base_url.length > 0;
-  }
-
-  function getProviderLabel(value: string) {
-    return PROVIDER_OPTIONS.find((p) => p.value === value)?.label || value;
-  }
-
-  function formatDate(iso: string) {
-    if (!iso) return "";
-    try {
-      return new Date(iso).toLocaleDateString(undefined, {
-        year: "numeric", month: "short", day: "numeric",
-        hour: "2-digit", minute: "2-digit",
-      });
-    } catch { return iso; }
-  }
-
-  function providerIndicatorState(provider: any): "live-ok" | "live-error" | "has-history" | "needs-validation" {
-    if (provider.last_validation_at) return provider.last_validation_ok ? "live-ok" : "live-error";
-    if (provider.validated_at) return "has-history";
-    return "needs-validation";
-  }
-
-  function lastValidationAt(provider: any) {
-    return provider.last_validation_at || provider.validated_at || "";
-  }
-</script>
-
-<div class="providers-page">
-  <div class="page-header">
-    <h1>Providers</h1>
-    {#if hasComponents}
-      <button class="primary-btn" onclick={() => (showAddForm = !showAddForm)}>
-        {showAddForm ? "Cancel" : "+ Add Provider"}
-      </button>
-    {/if}
-  </div>
-
-  {#if message}
-    <div class="message" class:success={messageTone === "success"} class:error={messageTone === "error"}>{message}</div>
-  {/if}
-
-  {#if error}
-    <div class="error-message">{error}</div>
-  {/if}
-
-  {#if !hasComponents}
-    <div class="empty-state">
-      <p>Install a component first to add providers.</p>
-      <a href="/install" class="link-btn">Install Component</a>
-    </div>
-  {:else if showAddForm}
-    <div class="add-form">
-      <h2>Add Provider</h2>
-      <div class="field">
-        <label for="add-provider">Provider</label>
-        <select id="add-provider" bind:value={addForm.provider}>
-          {#each PROVIDER_OPTIONS as opt}
-            <option value={opt.value}>{opt.label}</option>
-          {/each}
-        </select>
-      </div>
-      {#if addForm.provider === OPENAI_COMPATIBLE_VALUE}
-        <div class="field">
-          <label for="add-provider-name">Provider Name</label>
-          <input id="add-provider-name" type="text" bind:value={addForm.provider_name} placeholder="e.g. infini-ai, xiaomi-mimo" />
-        </div>
-        <div class="field">
-          <label for="add-base-url">Base URL</label>
-          <input id="add-base-url" type="text" bind:value={addForm.base_url} placeholder="https://api.example.com/v1" />
-        </div>
-      {/if}
-      {#if !isLocal(addForm.provider)}
-        <div class="field">
-          <label for="add-api-key">API Key</label>
-          <input id="add-api-key" type="password" bind:value={addForm.api_key} placeholder="Enter API key..." />
-        </div>
-      {/if}
-      <div class="field">
-        <label for="add-model">Model (optional)</label>
-        <input id="add-model" type="text" bind:value={addForm.model} placeholder="e.g. anthropic/claude-sonnet-4" />
-      </div>
-      {#if addError}
-        <div class="error-message">{addError}</div>
-      {/if}
-      <button class="primary-btn" onclick={handleAdd} disabled={addValidating}>
-        {addValidating ? "Validating..." : "Validate & Save"}
-      </button>
-    </div>
-  {/if}
-
-  {#if loading}
-    <p class="loading">Loading providers...</p>
-  {:else if providers.length === 0 && hasComponents}
-    <div class="empty-state">
-      <p>No saved providers yet. Add one above or install a component — providers are saved automatically during setup.</p>
-    </div>
-  {:else}
-    <div class="provider-grid">
-      {#each providers as p}
-        <div class="provider-card">
-          {#if editingId === p.id}
-            <div class="edit-form">
-              <div class="field">
-                <label for="edit-name-{p.id}">Name</label>
-                <input id="edit-name-{p.id}" type="text" bind:value={editForm.name} />
-              </div>
-              {#if isOpenAiCompatible(p)}
-                <div class="field">
-                  <label for="edit-base-url-{p.id}">Base URL</label>
-                  <input id="edit-base-url-{p.id}" type="text" bind:value={editForm.base_url} placeholder="https://api.example.com/v1" />
-                </div>
-              {/if}
-              {#if !isLocal(p.provider)}
-                <div class="field">
-                  <label for="edit-key-{p.id}">API Key (leave empty to keep current)</label>
-                  <input id="edit-key-{p.id}" type="password" bind:value={editForm.api_key} placeholder="Leave empty to keep current" />
-                </div>
-              {/if}
-              <div class="field">
-                <label for="edit-model-{p.id}">Model</label>
-                <input id="edit-model-{p.id}" type="text" bind:value={editForm.model} placeholder="e.g. anthropic/claude-sonnet-4" />
               </div>
               {#if editError}
                 <div class="error-message">{editError}</div>

--- a/ui/src/routes/providers/+page.svelte
+++ b/ui/src/routes/providers/+page.svelte
@@ -37,6 +37,464 @@
   let addForm = $state({ provider: "openrouter", provider_name: "", api_key: "", model: "", base_url: "" });
   let addValidating = $state(false);
   let addError = $state("");
+  let addProbing = $state(false);
+  let addProbedModels = $state<string[]>([]);
+  let addProbeError = $state("");
+
+  // Edit state
+  let editingId = $state<string | null>(null);
+  let editForm = $state({ name: "", api_key: "", model: "", base_url: "" });
+  let editValidating = $state(false);
+  let editError = $state("");
+  let editProbing = $state(false);
+  let editProbedModels = $state<string[]>([]);
+  let editProbeError = $state("");
+
+  // Re-validate state
+  let revalidatingId = $state<string | null>(null);
+
+  let hasComponents = $state(false);
+
+  onMount(async () => {
+    await loadProviders();
+    try {
+      const status = await api.getStatus();
+      hasComponents = Object.keys(status.instances || {}).length > 0;
+    } catch {}
+  });
+
+  onDestroy(() => {
+    if (messageTimer) clearTimeout(messageTimer);
+  });
+
+  function flashMessage(text: string, tone: "success" | "error" = "success", timeoutMs = 3000) {
+    message = text;
+    messageTone = tone;
+    if (messageTimer) clearTimeout(messageTimer);
+    messageTimer = setTimeout(() => {
+      message = "";
+      messageTimer = null;
+    }, timeoutMs);
+  }
+
+  async function loadProviders() {
+    loading = true;
+    error = "";
+    try {
+      const data = await api.getSavedProviders();
+      providers = data.providers || [];
+    } catch (e) {
+      error = (e as Error).message;
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function fetchAddModels() {
+    addProbing = true;
+    addProbeError = "";
+    addProbedModels = [];
+    try {
+      const result = await api.probeProviderModels(addForm.base_url.trim(), addForm.api_key.trim());
+      if (result.live_ok) {
+        addProbedModels = result.models;
+        if (!addProbedModels.length) addProbeError = "Connected, but no models returned.";
+      } else {
+        addProbeError = result.reason || "Could not reach endpoint.";
+      }
+    } catch (e) {
+      addProbeError = (e as Error).message;
+    } finally {
+      addProbing = false;
+    }
+  }
+
+  async function fetchEditModels() {
+    editProbing = true;
+    editProbeError = "";
+    editProbedModels = [];
+    const key = editForm.api_key.trim() || "(current key)";
+    try {
+      const result = await api.probeProviderModels(editForm.base_url.trim(), editForm.api_key.trim() || key);
+      if (result.live_ok) {
+        editProbedModels = result.models;
+        if (!editProbedModels.length) editProbeError = "Connected, but no models returned.";
+      } else {
+        editProbeError = result.reason || "Could not reach endpoint.";
+      }
+    } catch (e) {
+      editProbeError = (e as Error).message;
+    } finally {
+      editProbing = false;
+    }
+  }
+
+  async function handleAdd() {
+    addValidating = true;
+    addError = "";
+    try {
+      const providerValue = addForm.provider === OPENAI_COMPATIBLE_VALUE
+        ? addForm.provider_name.trim()
+        : addForm.provider;
+      if (addForm.provider === OPENAI_COMPATIBLE_VALUE && !providerValue) {
+        addError = "Provider name is required for OpenAI Compatible providers.";
+        addValidating = false;
+        return;
+      }
+      if (addForm.provider === OPENAI_COMPATIBLE_VALUE && !addForm.base_url.trim()) {
+        addError = "Base URL is required for OpenAI Compatible providers.";
+        addValidating = false;
+        return;
+      }
+      await api.createSavedProvider({
+        provider: providerValue,
+        api_key: addForm.api_key,
+        model: addForm.model || undefined,
+        base_url: addForm.base_url || undefined,
+      });
+      showAddForm = false;
+      addForm = { provider: "openrouter", provider_name: "", api_key: "", model: "", base_url: "" };
+      addProbedModels = [];
+      addProbeError = "";
+      flashMessage("Provider saved");
+      await loadProviders();
+    } catch (e) {
+      addError = (e as Error).message;
+    } finally {
+      addValidating = false;
+    }
+  }
+
+  function startEdit(p: any) {
+    editingId = p.id;
+    editForm = { name: p.name, api_key: "", model: p.model, base_url: p.base_url || "" };
+    editProbedModels = [];
+    editProbeError = "";
+  }
+
+  function cancelEdit() {
+    editingId = null;
+  }
+
+  async function saveEdit(id: string) {
+    editValidating = true;
+    editError = "";
+    try {
+      const payload: any = {};
+      if (editForm.name) payload.name = editForm.name;
+      if (editForm.api_key) payload.api_key = editForm.api_key;
+      payload.model = editForm.model;
+      payload.base_url = editForm.base_url;
+      await api.updateSavedProvider(id, payload);
+      editingId = null;
+      flashMessage("Provider updated");
+      await loadProviders();
+    } catch (e) {
+      editError = (e as Error).message;
+      await loadProviders();
+    } finally {
+      editValidating = false;
+    }
+  }
+
+  async function handleDelete(id: string) {
+    try {
+      await api.deleteSavedProvider(id);
+      flashMessage("Provider deleted");
+      await loadProviders();
+    } catch (e) {
+      error = (e as Error).message;
+    }
+  }
+
+  async function handleRevalidate(id: string) {
+    revalidatingId = id;
+    try {
+      await api.revalidateSavedProvider(id);
+      flashMessage("Validation passed", "success", 5000);
+    } catch (e) {
+      flashMessage(`Validation failed: ${(e as Error).message}`, "error", 5000);
+    } finally {
+      await loadProviders();
+      revalidatingId = null;
+    }
+  }
+
+  function isLocal(provider: string) {
+    return LOCAL_PROVIDERS.includes(provider);
+  }
+
+  function isOpenAiCompatible(p: any) {
+    return p.base_url && p.base_url.length > 0;
+  }
+
+  function getProviderLabel(value: string) {
+    return PROVIDER_OPTIONS.find((p) => p.value === value)?.label || value;
+  }
+
+  function formatDate(iso: string) {
+    if (!iso) return "";
+    try {
+      return new Date(iso).toLocaleDateString(undefined, {
+        year: "numeric", month: "short", day: "numeric",
+        hour: "2-digit", minute: "2-digit",
+      });
+    } catch { return iso; }
+  }
+
+  function providerIndicatorState(provider: any): "live-ok" | "live-error" | "has-history" | "needs-validation" {
+    if (provider.last_validation_at) return provider.last_validation_ok ? "live-ok" : "live-error";
+    if (provider.validated_at) return "has-history";
+    return "needs-validation";
+  }
+
+  function lastValidationAt(provider: any) {
+    return provider.last_validation_at || provider.validated_at || "";
+  }
+
+  $effect(() => {
+    // Clear probed models when the add form's base_url or api_key changes
+    addForm.base_url;
+    addForm.api_key;
+    addProbedModels = [];
+    addProbeError = "";
+  });
+</script>
+
+<div class="providers-page">
+  <div class="page-header">
+    <h1>Providers</h1>
+    {#if hasComponents}
+      <button class="primary-btn" onclick={() => (showAddForm = !showAddForm)}>
+        {showAddForm ? "Cancel" : "+ Add Provider"}
+      </button>
+    {/if}
+  </div>
+
+  {#if message}
+    <div class="message" class:success={messageTone === "success"} class:error={messageTone === "error"}>{message}</div>
+  {/if}
+
+  {#if error}
+    <div class="error-message">{error}</div>
+  {/if}
+
+  {#if !hasComponents}
+    <div class="empty-state">
+      <p>Install a component first to add providers.</p>
+      <a href="/install" class="link-btn">Install Component</a>
+    </div>
+  {:else if showAddForm}
+    <div class="add-form">
+      <h2>Add Provider</h2>
+      <div class="field">
+        <label for="add-provider">Provider</label>
+        <select id="add-provider" bind:value={addForm.provider}>
+          {#each PROVIDER_OPTIONS as opt}
+            <option value={opt.value}>{opt.label}</option>
+          {/each}
+        </select>
+      </div>
+      {#if addForm.provider === OPENAI_COMPATIBLE_VALUE}
+        <div class="field">
+          <label for="add-provider-name">Provider Name</label>
+          <input id="add-provider-name" type="text" bind:value={addForm.provider_name} placeholder="e.g. infini-ai, xiaomi-mimo" />
+        </div>
+        <div class="field">
+          <label for="add-base-url">Base URL</label>
+          <input id="add-base-url" type="text" bind:value={addForm.base_url} placeholder="https://api.example.com/v1" />
+        </div>
+      {/if}
+      {#if !isLocal(addForm.provider)}
+        <div class="field">
+          <label for="add-api-key">API Key</label>
+          <input id="add-api-key" type="password" bind:value={addForm.api_key} placeholder="Enter API key..." />
+        </div>
+      {/if}
+      {#if addForm.provider === OPENAI_COMPATIBLE_VALUE}
+        <div class="field">
+          <label for="add-model">Model</label>
+          <div class="model-input-row">
+            <input id="add-model" type="text" bind:value={addForm.model} placeholder="e.g. gpt-4" />
+            <button
+              class="btn fetch-models-btn"
+              onclick={fetchAddModels}
+              disabled={addProbing || !addForm.base_url.trim() || !addForm.api_key.trim()}
+              title="Fetch available models from this endpoint"
+            >
+              {addProbing ? "Fetching..." : "Fetch Models"}
+            </button>
+          </div>
+          {#if addProbeError}
+            <div class="probe-error">{addProbeError}</div>
+          {/if}
+          {#if addProbedModels.length > 0}
+            <div class="model-list">
+              {#each addProbedModels as m}
+                <button
+                  class="model-chip"
+                  class:selected={addForm.model === m}
+                  onclick={() => { addForm.model = m; }}
+                >{m}</button>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {:else}
+        <div class="field">
+          <label for="add-model">Model (optional)</label>
+          <input id="add-model" type="text" bind:value={addForm.model} placeholder="e.g. anthropic/claude-sonnet-4" />
+        </div>
+      {/if}
+      {#if addError}
+        <div class="error-message">{addError}</div>
+      {/if}
+      <button class="primary-btn" onclick={handleAdd} disabled={addValidating}>
+        {addValidating ? "Validating..." : "Save"}
+      </button>
+    </div>
+  {/if}
+
+  {#if loading}
+    <p class="loading">Loading providers...</p>
+  {:else if providers.length === 0 && hasComponents}
+    <div class="empty-state">
+      <p>No saved providers yet. Add one above or install a component — providers are saved automatically during setup.</p>
+    </div>
+  {:else}
+    <div class="provider-grid">
+      {#each providers as p}
+        <div class="provider-card">
+          {#if editingId === p.id}
+            <div class="edit-form">
+              <div class="field">
+                <label for="edit-name-{p.id}">Name</label>
+                <input id="edit-name-{p.id}" type="text" bind:value={editForm.name} />
+              </div>
+              {#if isOpenAiCompatible(p)}
+                <div class="field">
+                  <label for="edit-base-url-{p.id}">Base URL</label>
+                  <input id="edit-base-url-{p.id}" type="text" bind:value={editForm.base_url} placeholder="https://api.example.com/v1" />
+                </div>
+              {/if}
+              {#if !isLocal(p.provider)}
+                <div class="field">
+                  <label for="edit-key-{p.id}">API Key (leave empty to keep current)</label>
+                  <input id="edit-key-{p.id}" type="password" bind:value={editForm.api_key} placeholder="Leave empty to keep current" />
+                </div>
+              {/if}
+              <div class="field">
+                <label for="edit-model-{p.id}">Model</label>
+                {#if isOpenAiCompatible(p)}
+                  <div class="model-input-row">
+                    <input id="edit-model-{p.id}" type="text" bind:value={editForm.model} placeholder="e.g. gpt-4" />
+                    <button
+                      class="btn fetch-models-btn"
+                      onclick={fetchEditModels}
+                      disabled={editProbing || !editForm.base_url.trim()}
+                      title="Fetch available models from this endpoint"
+                    >
+                      {editProbing ? "Fetching..." : "Fetch Models"}
+                    </button>
+                  </div>
+                  {#if editProbeError}
+                    <div class="probe-error">{editProbeError}</div>
+                  {/if}
+                  {#if editProbedModels.length > 0}
+                    <div class="model-list">
+                      {#each editProbedModels as m}
+                        <button
+                          class="model-chip"
+                          class:selected={editForm.model === m}
+                          onclick={() => { editForm.model = m; }}
+                        >{m}</button>
+                      {/each}
+                    </div>
+                  {/if}
+                {:else}
+                  <input id="edit-model-{p.id}" type="text" bind:value={editForm.model} placeholder="e.g. anthropic/claude-sonnet-4" />
+                {/if}
+              </div>
+              {#if editError}
+                <div class="error-message">{editError}</div>
+              {/if}
+              <div class="edit-actions">
+                <button class="primary-btn" onclick={() => saveEdit(p.id)} disabled={editValidating}>
+                  {editValidating ? "Saving..." : "Save"}
+                </button>
+                <button class="btn" onclick={cancelEdit}>Cancel</button>
+              </div>
+            </div>
+          {:else}
+            {@const indicator = providerIndicatorState(p)}
+            <div class="card-header">
+              <div class="card-title">
+                <span
+                  class="status-dot"
+                  class:live-ok={indicator === "live-ok"}
+                  class:live-error={indicator === "live-error"}
+                  class:has-history={indicator === "has-history"}
+                  class:needs-validation={indicator === "needs-validation"}
+                ></span>
+                <h3>{p.name}</h3>
+              </div>
+              <span class="provider-type">{getProviderLabel(p.provider)}</span>
+            </div>
+            <div class="card-body">
+              <div class="card-field">
+                <span class="label">API Key</span>
+                <code>{p.api_key}</code>
+              </div>
+              {#if p.base_url}
+                <div class="card-field">
+                  <span class="label">Base URL</span>
+                  <code>{p.base_url}</code>
+                </div>
+              {/if}
+              <div class="card-field">
+                <span class="label">Model</span>
+                <code>{p.model || "No default model"}</code>
+              </div>
+              {#if p.validated_at}
+                <div class="card-field">
+                  <span class="label">Last Successful Validation</span>
+                  <span>{formatDate(p.validated_at)}</span>
+                </div>
+              {/if}
+              <div class="card-field">
+                <span class="label">Last Validation</span>
+                <span>{formatDate(lastValidationAt(p)) || "Never"}</span>
+              </div>
+              {#if !lastValidationAt(p)}
+                <div class="card-note">Not validated yet. Use Re-validate to run a live auth check.</div>
+              {/if}
+            </div>
+            <div class="card-actions">
+              <button class="btn" onclick={() => handleRevalidate(p.id)} disabled={revalidatingId === p.id}>
+                {revalidatingId === p.id ? "Validating..." : "Re-validate"}
+              </button>
+              <button class="btn" onclick={() => startEdit(p)}>Edit</button>
+              <button class="btn danger" onclick={() => handleDelete(p.id)}>Delete</button>
+            </div>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+  let providers = $state<any[]>([]);
+  let loading = $state(true);
+  let error = $state("");
+  let message = $state("");
+  let messageTone = $state<"success" | "error">("success");
+  let messageTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Add form state
+  let showAddForm = $state(false);
+  let addForm = $state({ provider: "openrouter", provider_name: "", api_key: "", model: "", base_url: "" });
+  let addValidating = $state(false);
+  let addError = $state("");
 
   // Edit state
   let editingId = $state<string | null>(null);
@@ -699,5 +1157,57 @@
 
   .edit-form {
     padding: 0.5rem 0;
+  }
+
+  .model-input-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: stretch;
+  }
+
+  .model-input-row input {
+    flex: 1;
+  }
+
+  .fetch-models-btn {
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+
+  .model-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    margin-top: 0.5rem;
+  }
+
+  .model-chip {
+    padding: 0.25rem 0.625rem;
+    background: var(--bg-surface);
+    color: var(--fg-dim);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    font-size: 0.75rem;
+    font-family: var(--font-mono);
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+
+  .model-chip:hover {
+    border-color: var(--accent-dim);
+    color: var(--fg);
+  }
+
+  .model-chip.selected {
+    background: color-mix(in srgb, var(--accent) 15%, transparent);
+    border-color: var(--accent);
+    color: var(--accent);
+    text-shadow: var(--text-glow);
+  }
+
+  .probe-error {
+    margin-top: 0.375rem;
+    font-size: 0.75rem;
+    color: var(--error, #e55);
   }
 </style>

--- a/ui/src/routes/providers/+page.svelte
+++ b/ui/src/routes/providers/+page.svelte
@@ -307,7 +307,7 @@
             <button
               class="btn fetch-models-btn"
               onclick={fetchAddModels}
-              disabled={addProbing || !addForm.base_url.trim() || !addForm.api_key.trim()}
+              disabled={addProbing || !addForm.base_url.trim()}
               title="Fetch available models from this endpoint"
             >
               {addProbing ? "Fetching..." : "Fetch Models"}

--- a/ui/src/routes/providers/+page.svelte
+++ b/ui/src/routes/providers/+page.svelte
@@ -1,32 +1,8 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
   import { api } from "$lib/api/client";
+  import { PROVIDER_OPTIONS, OPENAI_COMPATIBLE_VALUE, LOCAL_PROVIDERS, KNOWN_PROVIDER_VALUES } from "$lib/providers";
 
-  const PROVIDER_OPTIONS = [
-    { value: "openrouter", label: "OpenRouter (multi-provider, recommended)", recommended: true },
-    { value: "anthropic", label: "Anthropic" },
-    { value: "openai", label: "OpenAI" },
-    { value: "google", label: "Google AI" },
-    { value: "mistral", label: "Mistral" },
-    { value: "groq", label: "Groq" },
-    { value: "deepseek", label: "DeepSeek" },
-    { value: "cohere", label: "Cohere" },
-    { value: "together", label: "Together AI" },
-    { value: "fireworks", label: "Fireworks AI" },
-    { value: "perplexity", label: "Perplexity" },
-    { value: "xai", label: "xAI" },
-    { value: "ollama", label: "Ollama (local)" },
-    { value: "lm-studio", label: "LM Studio (local)" },
-    { value: "claude-cli", label: "Claude CLI (local)" },
-    { value: "codex-cli", label: "Codex CLI (local CLI)" },
-    { value: "openai-codex", label: "OpenAI Codex (ChatGPT login)" },
-    { value: "openai-compatible", label: "OpenAI Compatible (custom endpoint)" },
-  ];
-  const LOCAL_PROVIDERS = ["ollama", "lm-studio", "claude-cli", "codex-cli", "openai-codex"];
-  const OPENAI_COMPATIBLE_VALUE = "openai-compatible";
-  const KNOWN_PROVIDER_VALUES = new Set(
-    PROVIDER_OPTIONS.filter(o => o.value !== OPENAI_COMPATIBLE_VALUE).map(o => o.value)
-  );
 
   let providers = $state<any[]>([]);
   let loading = $state(true);


### PR DESCRIPTION
## Summary
- add `GET /api/providers/probe-models?base_url=&api_key=` so custom OpenAI-compatible endpoints can be validated and their `/v1/models` list fetched before saving
- route OpenAI-compatible model selection and validation through the HTTP probe instead of `nullclaw --list-models`, which only understands built-in provider names
- patch generated configs for custom providers by writing the real provider entry, removing the temporary `openai` placeholder, setting `agents.defaults.model.primary`, and populating `agent.vision_disabled_models` for inference-time image stripping
- increase provider health probe timeouts from `10` to `30` seconds in both instance and wizard flows so healthy custom endpoints are not misclassified as failed

## Validation
- `zig build test -Dbuild-ui=false --summary all`
- manual custom-provider probe against live OpenAI-compatible endpoints

## Notes
- the earlier NullClaw startup diagnosis was incorrect and has been removed from this PR
- the managed-start regression is handled separately in #38
