### PR TITLE
test(fixtures): add reusable temp paths helper

### DIFF
--- a/src/api/channels.zig
+++ b/src/api/channels.zig
@@ -6,6 +6,7 @@ const helpers = @import("helpers.zig");
 const wizard_api = @import("wizard.zig");
 const providers_api = @import("providers.zig");
 const component_cli = @import("../core/component_cli.zig");
+const test_helpers = @import("../test_helpers.zig");
 
 const appendEscaped = helpers.appendEscaped;
 
@@ -537,7 +538,10 @@ test "hasRevealParam detects reveal query param" {
 
 test "handleList returns empty array for no channels" {
     const allocator = std.testing.allocator;
-    const path = "/tmp/nullhub-channel-test-list.json";
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
+    defer allocator.free(path);
     var s = state_mod.State.init(allocator, path);
     defer s.deinit();
 
@@ -548,7 +552,10 @@ test "handleList returns empty array for no channels" {
 
 test "handleList masks secrets in config" {
     const allocator = std.testing.allocator;
-    const path = "/tmp/nullhub-channel-test-mask.json";
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
+    defer allocator.free(path);
     var s = state_mod.State.init(allocator, path);
     defer s.deinit();
 
@@ -569,7 +576,10 @@ test "handleList masks secrets in config" {
 
 test "handleList reveals secrets when requested" {
     const allocator = std.testing.allocator;
-    const path = "/tmp/nullhub-channel-test-reveal.json";
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
+    defer allocator.free(path);
     var s = state_mod.State.init(allocator, path);
     defer s.deinit();
 
@@ -587,12 +597,9 @@ test "handleList reveals secrets when requested" {
 
 test "handleDelete removes channel" {
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-channel-test-delete";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    std_compat.fs.makeDirAbsolute(tmp) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-
-    const path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
     defer allocator.free(path);
 
     var s = state_mod.State.init(allocator, path);
@@ -608,7 +615,10 @@ test "handleDelete removes channel" {
 
 test "handleDelete returns error for unknown id" {
     const allocator = std.testing.allocator;
-    const path = "/tmp/nullhub-channel-test-del-unknown.json";
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
+    defer allocator.free(path);
     var s = state_mod.State.init(allocator, path);
     defer s.deinit();
 
@@ -619,18 +629,18 @@ test "handleDelete returns error for unknown id" {
 
 test "handleCreate rejects non-object config" {
     const allocator = std.testing.allocator;
-    const path = "/tmp/nullhub-channel-test-create-invalid.json";
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
+    defer allocator.free(path);
     var s = state_mod.State.init(allocator, path);
     defer s.deinit();
-
-    var paths = try paths_mod.Paths.init(allocator, "/tmp/nullhub-channel-test-create-invalid-root");
-    defer paths.deinit(allocator);
 
     const json = try handleCreate(
         allocator,
         "{\"channel_type\":\"telegram\",\"account\":\"default\",\"config\":null}",
         &s,
-        paths,
+        fixture.paths,
     );
     defer allocator.free(json);
     try std.testing.expectEqualStrings("{\"error\":\"config must be an object\"}", json);
@@ -638,12 +648,9 @@ test "handleCreate rejects non-object config" {
 
 test "handleUpdate rejects non-object config" {
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-channel-test-update-invalid";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    try std_compat.fs.makeDirAbsolute(tmp);
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-
-    const path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
     defer allocator.free(path);
 
     var s = state_mod.State.init(allocator, path);
@@ -654,15 +661,12 @@ test "handleUpdate rejects non-object config" {
         .config = "{\"bot_token\":\"abc\"}",
     });
 
-    var paths = try paths_mod.Paths.init(allocator, tmp);
-    defer paths.deinit(allocator);
-
     const json = try handleUpdate(
         allocator,
         1,
         "{\"config\":false}",
         &s,
-        paths,
+        fixture.paths,
     );
     defer allocator.free(json);
     try std.testing.expectEqualStrings("{\"error\":\"config must be an object\"}", json);
@@ -670,14 +674,12 @@ test "handleUpdate rejects non-object config" {
 
 test "writeChannelConfig escapes channel type and account" {
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-channel-test-config-escape";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    try std_compat.fs.makeDirAbsolute(tmp);
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    try writeChannelConfig(allocator, tmp, "telegram", "acct\"name\\slash", "{\"token\":\"abc\"}");
+    try writeChannelConfig(allocator, fixture.root, "telegram", "acct\"name\\slash", "{\"token\":\"abc\"}");
 
-    const config_path = try std.fmt.allocPrint(allocator, "{s}/config.json", .{tmp});
+    const config_path = try fixture.path(allocator, "config.json");
     defer allocator.free(config_path);
     const bytes = try std_compat.fs.cwd().readFileAlloc(allocator, config_path, 4096);
     defer allocator.free(bytes);

--- a/src/api/components.zig
+++ b/src/api/components.zig
@@ -3,6 +3,7 @@ const std_compat = @import("compat");
 const registry = @import("../installer/registry.zig");
 const paths_mod = @import("../core/paths.zig");
 const state_mod = @import("../core/state.zig");
+const test_helpers = @import("../test_helpers.zig");
 
 // ─── Display name derivation ─────────────────────────────────────────────────
 
@@ -177,7 +178,11 @@ test "deriveDisplayName capitalizes first letter" {
 
 test "handleList returns valid JSON with all 3 known components" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-components.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     const json = try handleList(allocator, &s);

--- a/src/api/config.zig
+++ b/src/api/config.zig
@@ -6,6 +6,7 @@ const state_mod = @import("../core/state.zig");
 const helpers = @import("helpers.zig");
 const managed_cli = @import("managed_cli.zig");
 const query = @import("query.zig");
+const test_helpers = @import("../test_helpers.zig");
 
 const ApiResponse = helpers.ApiResponse;
 
@@ -260,34 +261,26 @@ test "isConfigPath detects config suffix" {
 
 test "handleGet returns 404 when no config file exists" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-config-api-get";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
-
-    const resp = handleGet(allocator, p, "nullclaw", "my-agent", "/api/instances/nullclaw/my-agent/config");
+    const resp = handleGet(allocator, fixture.paths, "nullclaw", "my-agent", "/api/instances/nullclaw/my-agent/config");
     try std.testing.expectEqualStrings("404 Not Found", resp.status);
     try std.testing.expectEqualStrings("{\"error\":\"config not found\"}", resp.body);
 }
 
 test "handlePut writes config file" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-config-api-put";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
     const body = "{\"key\":\"value\"}";
-    const resp = handlePut(allocator, p, "nullclaw", "my-agent", body);
+    const resp = handlePut(allocator, fixture.paths, "nullclaw", "my-agent", body);
     try std.testing.expectEqualStrings("200 OK", resp.status);
     try std.testing.expectEqualStrings("{\"status\":\"saved\"}", resp.body);
 
     // Verify the file was written.
-    const config_path = try p.instanceConfig(allocator, "nullclaw", "my-agent");
+    const config_path = try fixture.paths.instanceConfig(allocator, "nullclaw", "my-agent");
     defer allocator.free(config_path);
 
     const file = try std_compat.fs.openFileAbsolute(config_path, .{});
@@ -299,18 +292,14 @@ test "handlePut writes config file" {
 
 test "handleGet reads written config" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-config-api-roundtrip";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
     const body = "{\"port\":8080}";
-    const put_resp = handlePut(allocator, p, "nullclaw", "my-agent", body);
+    const put_resp = handlePut(allocator, fixture.paths, "nullclaw", "my-agent", body);
     try std.testing.expectEqualStrings("200 OK", put_resp.status);
 
-    const get_resp = handleGet(allocator, p, "nullclaw", "my-agent", "/api/instances/nullclaw/my-agent/config");
+    const get_resp = handleGet(allocator, fixture.paths, "nullclaw", "my-agent", "/api/instances/nullclaw/my-agent/config");
     defer allocator.free(get_resp.body);
     try std.testing.expectEqualStrings("200 OK", get_resp.status);
     try std.testing.expectEqualStrings(body, get_resp.body);
@@ -318,18 +307,14 @@ test "handleGet reads written config" {
 
 test "handleGet returns a single dotted-path value when path query is present" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-config-api-path";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
     const body = "{\"gateway\":{\"port\":8080},\"default_provider\":\"openrouter\"}";
-    const put_resp = handlePut(allocator, p, "nullclaw", "my-agent", body);
+    const put_resp = handlePut(allocator, fixture.paths, "nullclaw", "my-agent", body);
     try std.testing.expectEqualStrings("200 OK", put_resp.status);
 
-    const get_resp = handleGet(allocator, p, "nullclaw", "my-agent", "/api/instances/nullclaw/my-agent/config?path=gateway.port");
+    const get_resp = handleGet(allocator, fixture.paths, "nullclaw", "my-agent", "/api/instances/nullclaw/my-agent/config?path=gateway.port");
     defer allocator.free(get_resp.body);
     try std.testing.expectEqualStrings("200 OK", get_resp.status);
     try std.testing.expectEqualStrings("{\"path\":\"gateway.port\",\"value\":8080}", get_resp.body);
@@ -339,19 +324,17 @@ test "handleGetManaged prefers nullclaw CLI JSON when available" {
     if (comptime @import("builtin").os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-config-api-managed";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-config-api-managed-state.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
     try writeManagedTestBinary(
         allocator,
-        p,
+        fixture.paths,
         "nullclaw",
         "1.0.0",
         \\#!/bin/sh
@@ -367,7 +350,7 @@ test "handleGetManaged prefers nullclaw CLI JSON when available" {
     const resp = handleGetManaged(
         allocator,
         &s,
-        p,
+        fixture.paths,
         "nullclaw",
         "my-agent",
         "/api/instances/nullclaw/my-agent/config?path=gateway.port",
@@ -381,19 +364,17 @@ test "handleGetManaged maps managed nullclaw config misses to 404" {
     if (comptime @import("builtin").os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-config-api-managed-not-found";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-config-api-managed-not-found-state.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.1" });
     try writeManagedTestBinary(
         allocator,
-        p,
+        fixture.paths,
         "nullclaw",
         "1.0.1",
         \\#!/bin/sh
@@ -409,7 +390,7 @@ test "handleGetManaged maps managed nullclaw config misses to 404" {
     const resp = handleGetManaged(
         allocator,
         &s,
-        p,
+        fixture.paths,
         "nullclaw",
         "my-agent",
         "/api/instances/nullclaw/my-agent/config?path=missing.path",
@@ -423,19 +404,17 @@ test "handleGetManaged rejects malformed managed CLI JSON" {
     if (comptime @import("builtin").os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-config-api-managed-invalid-json";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-config-api-managed-invalid-json-state.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.2" });
     try writeManagedTestBinary(
         allocator,
-        p,
+        fixture.paths,
         "nullclaw",
         "1.0.2",
         \\#!/bin/sh
@@ -451,7 +430,7 @@ test "handleGetManaged rejects malformed managed CLI JSON" {
     const resp = handleGetManaged(
         allocator,
         &s,
-        p,
+        fixture.paths,
         "nullclaw",
         "my-agent",
         "/api/instances/nullclaw/my-agent/config",
@@ -463,15 +442,11 @@ test "handleGetManaged rejects malformed managed CLI JSON" {
 
 test "handlePatch writes config (same as PUT for now)" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-config-api-patch";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
     const body = "{\"updated\":true}";
-    const resp = handlePatch(allocator, p, "nullclaw", "my-agent", body);
+    const resp = handlePatch(allocator, fixture.paths, "nullclaw", "my-agent", body);
     try std.testing.expectEqualStrings("200 OK", resp.status);
     try std.testing.expectEqualStrings("{\"status\":\"saved\"}", resp.body);
 }

--- a/src/api/instances.zig
+++ b/src/api/instances.zig
@@ -14,6 +14,7 @@ const manifest_mod = @import("../core/manifest.zig");
 const managed_cli = @import("managed_cli.zig");
 const nullclaw_web_channel = @import("../core/nullclaw_web_channel.zig");
 const query_api = @import("query.zig");
+const test_helpers = @import("../test_helpers.zig");
 
 const ApiResponse = helpers.ApiResponse;
 const appendEscaped = helpers.appendEscaped;
@@ -3851,22 +3852,25 @@ pub fn dispatch(
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 const TestManagerCtx = struct {
+    fixture: test_helpers.TempPaths,
     manager: manager_mod.Manager,
     mutex: std_compat.sync.Mutex = .{},
     paths: paths_mod.Paths,
 
     fn init(allocator: std.mem.Allocator) TestManagerCtx {
-        const p = paths_mod.Paths.init(allocator, "/tmp/nullhub-test-instances-api") catch @panic("Paths.init failed");
+        const fixture = test_helpers.TempPaths.init(allocator) catch @panic("TempPaths.init failed");
         return .{
-            .paths = p,
-            .manager = manager_mod.Manager.init(allocator, p),
+            .fixture = fixture,
+            .paths = fixture.paths,
+            .manager = manager_mod.Manager.init(allocator, fixture.paths),
             .mutex = .{},
         };
     }
 
     fn deinit(self: *TestManagerCtx, allocator: std.mem.Allocator) void {
+        _ = allocator;
         self.manager.deinit();
-        self.paths.deinit(allocator);
+        self.fixture.deinit();
     }
 };
 
@@ -4104,7 +4108,11 @@ test "parsePath: component only (no name) returns null" {
 
 test "handleList returns valid JSON structure" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4146,7 +4154,11 @@ test "handleList returns valid JSON structure" {
 
 test "handleGet returns 404 for missing instance" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4158,7 +4170,11 @@ test "handleGet returns 404 for missing instance" {
 
 test "handleGet returns instance detail JSON" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4194,13 +4210,14 @@ test "handleInstanceStatus uses nullclaw CLI when available" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-status-cli.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
     try writeTestBinary(
@@ -4229,7 +4246,11 @@ test "handleInstanceStatus uses nullclaw CLI when available" {
 
 test "handleInstanceStatus returns gateway error when managed CLI is unavailable" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-status-fallback.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4245,7 +4266,11 @@ test "handleInstanceStatus returns gateway error when managed CLI is unavailable
 
 test "handleStart returns 404 for missing instance" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4256,15 +4281,19 @@ test "handleStart returns 404 for missing instance" {
 
 test "handleStart returns 500 when binary does not exist" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
 
-    // Binary doesn't exist at /tmp/nullhub-test-instances-api/bin/nullclaw-1.0.0
-    // so startInstance will fail and handler returns 500.
+    // The binary is absent from the isolated test root, so startInstance
+    // will fail and the handler returns 500.
     const resp = handleStart(allocator, &s, &mctx.manager, mctx.paths, "nullclaw", "my-agent", "");
     try std.testing.expectEqualStrings("500 Internal Server Error", resp.status);
 }
@@ -4273,13 +4302,14 @@ test "handleStart keeps gateway instances on their HTTP health port" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-start-gateway.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0", .launch_mode = "gateway" });
     try writeTestInstanceConfig(allocator, mctx.paths, "nullclaw", "my-agent", "{\"gateway\":{\"port\":43123}}");
@@ -4310,7 +4340,11 @@ test "handleStart keeps gateway instances on their HTTP health port" {
 
 test "handleStop returns 200 for existing instance" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4324,7 +4358,11 @@ test "handleStop returns 200 for existing instance" {
 
 test "handleRestart returns 500 when binary does not exist" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4338,7 +4376,11 @@ test "handleRestart returns 500 when binary does not exist" {
 
 test "handleDelete removes instance" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4355,13 +4397,14 @@ test "handleDelete removes instance" {
 
 test "handleDelete removes instance directory from active path" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-delete-path.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
     try writeTestInstanceConfig(allocator, mctx.paths, "nullclaw", "my-agent", "{\"gateway\":{\"port\":3000}}");
@@ -4381,20 +4424,16 @@ test "handleDelete removes instance directory from active path" {
 
 test "handleDelete restores instance when state save fails" {
     const allocator = std.testing.allocator;
-    const bad_state_root = "/tmp/nullhub-test-instances-api-delete-rollback";
-    std_compat.fs.deleteTreeAbsolute(bad_state_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(bad_state_root) catch {};
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
 
-    const bad_state_path = try std.fmt.allocPrint(allocator, "{s}/missing/state.json", .{bad_state_root});
+    const bad_state_path = try state_fixture.path(allocator, "missing/state.json");
     defer allocator.free(bad_state_path);
 
     var s = state_mod.State.init(allocator, bad_state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
     try writeTestInstanceConfig(allocator, mctx.paths, "nullclaw", "my-agent", "{\"gateway\":{\"port\":3000}}");
@@ -4410,7 +4449,11 @@ test "handleDelete restores instance when state save fails" {
 
 test "handleDelete returns 404 for missing instance" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4421,7 +4464,11 @@ test "handleDelete returns 404 for missing instance" {
 
 test "handlePatch updates auto_start" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0", .auto_start = false });
@@ -4435,7 +4482,11 @@ test "handlePatch updates auto_start" {
 
 test "handlePatch returns 404 for missing instance" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     const resp = handlePatch(&s, "nope", "nope", "{\"auto_start\":true}");
@@ -4444,7 +4495,11 @@ test "handlePatch returns 404 for missing instance" {
 
 test "handlePatch returns 400 for invalid JSON" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
@@ -4455,7 +4510,11 @@ test "handlePatch returns 400 for invalid JSON" {
 
 test "handlePatch updates launch_mode" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
@@ -4469,7 +4528,11 @@ test "handlePatch updates launch_mode" {
 
 test "handlePatch rejects invalid launch_mode" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
@@ -4483,7 +4546,11 @@ test "handlePatch rejects invalid launch_mode" {
 
 test "handlePatch updates verbose startup flag" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
@@ -4497,7 +4564,11 @@ test "handlePatch updates verbose startup flag" {
 
 test "handleGet includes launch_mode in JSON" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4513,7 +4584,11 @@ test "handleGet includes launch_mode in JSON" {
 
 test "handleGet includes verbose in JSON" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4529,7 +4604,11 @@ test "handleGet includes verbose in JSON" {
 
 test "dispatch routes GET /api/instances" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4545,7 +4624,11 @@ test "dispatch routes GET /api/instances" {
 
 test "dispatch routes POST start action" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4559,7 +4642,11 @@ test "dispatch routes POST start action" {
 
 test "dispatch routes GET provider-health action" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4575,13 +4662,14 @@ test "dispatch routes GET status action" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-status-dispatch.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
     try writeTestBinary(
@@ -4609,7 +4697,11 @@ test "dispatch routes GET status action" {
 
 test "dispatch routes GET models action returns gateway error when CLI is unavailable" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-models.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4627,13 +4719,14 @@ test "dispatch routes GET models action via nullclaw CLI when available" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-models-cli.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
     try writeTestBinary(
@@ -4664,13 +4757,14 @@ test "dispatch routes GET models action rejects malformed CLI JSON" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-models-invalid.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.1-invalid" });
     try writeTestBinary(
@@ -4697,7 +4791,11 @@ test "dispatch routes GET models action rejects malformed CLI JSON" {
 
 test "dispatch routes GET cron action returns gateway error when CLI is unavailable" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-cron.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -4715,13 +4813,14 @@ test "dispatch routes GET cron action via nullclaw CLI when available" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-cron-cli.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
     try writeTestBinary(
@@ -4751,13 +4850,14 @@ test "dispatch routes POST cron create action" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-cron-create.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
     try writeTestBinary(
@@ -4799,12 +4899,14 @@ test "dispatch routes POST cron create action" {
 
 test "handleOnboarding reports pending bootstrap for fresh nullclaw workspace" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
 
@@ -4830,12 +4932,14 @@ test "handleOnboarding reports pending bootstrap for fresh nullclaw workspace" {
 
 test "handleOnboarding reports pending bootstrap from workspace state without disk bootstrap file" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
 
@@ -4845,10 +4949,10 @@ test "handleOnboarding reports pending bootstrap from workspace state without di
     defer allocator.free(workspace_dir);
     try ensurePath(workspace_dir);
 
-    const state_path = try nullclawWorkspaceStatePath(allocator, workspace_dir);
-    defer allocator.free(state_path);
-    try ensurePath(std.fs.path.dirname(state_path).?);
-    const state_file = try std_compat.fs.createFileAbsolute(state_path, .{ .truncate = true });
+    const workspace_state_path = try nullclawWorkspaceStatePath(allocator, workspace_dir);
+    defer allocator.free(workspace_state_path);
+    try ensurePath(std.fs.path.dirname(workspace_state_path).?);
+    const state_file = try std_compat.fs.createFileAbsolute(workspace_state_path, .{ .truncate = true });
     defer state_file.close();
     try state_file.writeAll(
         "{\n  \"bootstrap_seeded_at\": \"2026-03-13T01:17:17Z\"\n}\n",
@@ -4866,13 +4970,14 @@ test "handleOnboarding reports pending bootstrap from workspace state without di
 
 test "handleOnboarding falls back to CLI bootstrap memory for legacy sqlite workspace" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "legacy-agent", .{ .version = "1.0.3" });
     const script =
@@ -4909,13 +5014,14 @@ test "handleOnboarding falls back to CLI bootstrap memory for legacy sqlite work
 
 test "handleOnboarding stays idle when legacy sqlite bootstrap memory is absent" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "empty-agent", .{ .version = "1.0.4" });
     const script =
@@ -4948,12 +5054,14 @@ test "handleOnboarding stays idle when legacy sqlite bootstrap memory is absent"
 
 test "dispatch routes GET onboarding action" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
 
@@ -4963,10 +5071,10 @@ test "dispatch routes GET onboarding action" {
     defer allocator.free(workspace_dir);
     try ensurePath(workspace_dir);
 
-    const state_path = try nullclawWorkspaceStatePath(allocator, workspace_dir);
-    defer allocator.free(state_path);
-    try ensurePath(std.fs.path.dirname(state_path).?);
-    const state_file = try std_compat.fs.createFileAbsolute(state_path, .{ .truncate = true });
+    const workspace_state_path = try nullclawWorkspaceStatePath(allocator, workspace_dir);
+    defer allocator.free(workspace_state_path);
+    try ensurePath(std.fs.path.dirname(workspace_state_path).?);
+    const state_file = try std_compat.fs.createFileAbsolute(workspace_state_path, .{ .truncate = true });
     defer state_file.close();
     try state_file.writeAll(
         "{\n  \"bootstrap_seeded_at\": \"2026-03-13T01:17:17Z\",\n  \"onboarding_completed_at\": \"2026-03-13T01:30:41Z\"\n}\n",
@@ -4981,12 +5089,14 @@ test "dispatch routes GET onboarding action" {
 
 test "dispatch routes GET integration action for linked nullboiler" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nulltickets", "tracker-a", .{ .version = "1.0.0" });
     try s.addInstance("nullboiler", "boiler-a", .{ .version = "1.0.0" });
@@ -5024,12 +5134,14 @@ test "dispatch routes GET integration action for linked nullboiler" {
 
 test "dispatch routes POST integration action for nullboiler" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nulltickets", "tracker-a", .{ .version = "1.0.0" });
     try s.addInstance("nullboiler", "boiler-a", .{ .version = "1.0.0" });
@@ -5086,12 +5198,14 @@ test "dispatch routes POST integration action for nullboiler" {
 
 test "dispatch integration relink preserves advanced tracker config and custom workflows" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nulltickets", "tracker-a", .{ .version = "1.0.0" });
     try s.addInstance("nullboiler", "boiler-a", .{ .version = "1.0.0" });
@@ -5206,7 +5320,11 @@ test "dispatch integration relink preserves advanced tracker config and custom w
 
 test "dispatch provider-health rejects POST" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -5219,7 +5337,11 @@ test "dispatch provider-health rejects POST" {
 
 test "handleUsage aggregates provider/model rows" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -5262,7 +5384,11 @@ test "handleUsage aggregates provider/model rows" {
 
 test "handleUsage refreshes cache immediately when ledger changes" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -5313,7 +5439,11 @@ test "handleUsage refreshes cache immediately when ledger changes" {
 
 test "dispatch routes GET usage action" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -5328,13 +5458,14 @@ test "dispatch routes GET usage action" {
 
 test "handleHistory returns CLI JSON and passes instance home" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0" });
     const script =
@@ -5371,13 +5502,14 @@ test "handleHistory returns CLI JSON and passes instance home" {
 
 test "handleMemory wraps legacy CLI failures as JSON errors" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.1" });
     const script =
@@ -5397,13 +5529,14 @@ test "handleMemory wraps legacy CLI failures as JSON errors" {
 
 test "handleMemory forwards q alias session_id and include_internal" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.2-q" });
     const script =
@@ -5444,13 +5577,14 @@ test "handleMemory forwards q alias session_id and include_internal" {
 
 test "handleMemory get returns 404 when CLI reports null" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.2-null" });
     const script =
@@ -5471,13 +5605,14 @@ test "handleMemory get returns 404 when CLI reports null" {
 
 test "handleMemoryWrite maps missing update to 404" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.2-patch" });
     const script =
@@ -5509,13 +5644,14 @@ test "handleMemoryWrite maps missing update to 404" {
 
 test "dispatch routes memory maintenance actions" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.2-maint" });
     const script =
@@ -5547,13 +5683,14 @@ test "dispatch routes memory maintenance actions" {
 
 test "dispatch routes GET skills action" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.2" });
     const script =
@@ -5576,13 +5713,14 @@ test "dispatch routes GET skills action" {
 
 test "handleSkills returns 404 when CLI detail returns null" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.2-skill-null" });
     const script =
@@ -5603,13 +5741,14 @@ test "handleSkills returns 404 when CLI detail returns null" {
 
 test "dispatch routes GET channels action" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.2" });
     const script =
@@ -5635,13 +5774,14 @@ test "dispatch routes GET channel detail maps missing type to 404" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-channel-detail-missing.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.2-missing" });
     const script =
@@ -5666,13 +5806,14 @@ test "dispatch routes GET channel detail via nullclaw CLI when available" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-channel-detail-cli.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.2-detail" });
     const script =
@@ -5697,7 +5838,11 @@ test "dispatch routes GET channel detail via nullclaw CLI when available" {
 
 test "dispatch routes GET skills catalog" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
@@ -5713,13 +5858,14 @@ test "dispatch routes GET skills catalog" {
 
 test "dispatch routes POST bundled skill install" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.2" });
     try writeTestInstanceConfig(allocator, mctx.paths, "nullclaw", "my-agent", "{\"autonomy\":{\"level\":\"supervised\"}}");
@@ -5756,13 +5902,14 @@ test "dispatch routes POST bundled skill install" {
 
 test "dispatch routes DELETE skills action" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.3" });
     const script =
@@ -5785,13 +5932,14 @@ test "dispatch routes DELETE skills action" {
 
 test "dispatch routes POST source install returns conflict on CLI failure" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.4" });
     const script =
@@ -5819,13 +5967,14 @@ test "dispatch routes POST source install returns conflict on CLI failure" {
 
 test "dispatch routes POST registry skill install alias" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.5" });
     const script =
@@ -5857,13 +6006,14 @@ test "dispatch routes POST registry skill install alias" {
 
 test "dispatch routes POST url skill install alias" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.6" });
     const script =
@@ -5897,13 +6047,14 @@ test "dispatch routes cron detail and lifecycle actions" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-cron-lifecycle.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.7" });
     try writeTestCronStore(
@@ -6029,13 +6180,14 @@ test "dispatch routes config mutation actions" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-config-actions.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.8" });
     const script =
@@ -6115,13 +6267,14 @@ test "dispatch routes doctor capabilities mcp and models detail" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-admin-read.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.9" });
     const script =
@@ -6186,13 +6339,14 @@ test "dispatch routes agent invoke stream and sessions" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-agent.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.10" });
     const script =
@@ -6257,13 +6411,14 @@ test "dispatch routes memory write read stats and search actions" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-memory-actions.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.11" });
     const script =
@@ -6352,13 +6507,14 @@ test "dispatch routes GET skill detail action" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api-skill-detail.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);
-
-    std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(mctx.paths.root) catch {};
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.12" });
     const script =
@@ -6382,7 +6538,11 @@ test "dispatch routes GET skill detail action" {
 
 test "dispatch returns null for non-matching path" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-instances-api.json");
+    var state_fixture = try test_helpers.TempPaths.init(allocator);
+    defer state_fixture.deinit();
+    const state_path = try state_fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     var mctx = TestManagerCtx.init(allocator);
     defer mctx.deinit(allocator);

--- a/src/api/logs.zig
+++ b/src/api/logs.zig
@@ -4,6 +4,7 @@ const fs_compat = @import("../fs_compat.zig");
 const paths_mod = @import("../core/paths.zig");
 const helpers = @import("helpers.zig");
 const query = @import("query.zig");
+const test_helpers = @import("../test_helpers.zig");
 
 const ApiResponse = helpers.ApiResponse;
 const appendEscaped = helpers.appendEscaped;
@@ -410,14 +411,10 @@ test "parseSource reads nullhub source" {
 
 test "handleGet returns empty lines when no log file" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-logs-api-empty";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
-
-    const resp = handleGet(allocator, p, "nullclaw", "my-agent", 100, .instance);
+    const resp = handleGet(allocator, fixture.paths, "nullclaw", "my-agent", 100, .instance);
     try std.testing.expectEqualStrings("200 OK", resp.status);
     defer allocator.free(resp.body);
     try std.testing.expectEqualStrings("{\"lines\":[]}", resp.body);
@@ -425,15 +422,11 @@ test "handleGet returns empty lines when no log file" {
 
 test "handleGet reads actual log content" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-logs-api-read";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
     // Create the logs directory and write a log file.
-    const logs_dir = try p.instanceLogs(allocator, "nullclaw", "my-agent");
+    const logs_dir = try fixture.paths.instanceLogs(allocator, "nullclaw", "my-agent");
     defer allocator.free(logs_dir);
 
     // Create directories recursively.
@@ -448,7 +441,7 @@ test "handleGet reads actual log content" {
         try file.writeAll("line1\nline2\nline3\n");
     }
 
-    const resp = handleGet(allocator, p, "nullclaw", "my-agent", 100, .instance);
+    const resp = handleGet(allocator, fixture.paths, "nullclaw", "my-agent", 100, .instance);
     defer allocator.free(resp.body);
 
     try std.testing.expectEqualStrings("200 OK", resp.status);
@@ -471,14 +464,10 @@ test "handleGet reads actual log content" {
 
 test "handleGet tails last N lines" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-logs-api-tail";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
-
-    const logs_dir = try p.instanceLogs(allocator, "nullclaw", "my-agent");
+    const logs_dir = try fixture.paths.instanceLogs(allocator, "nullclaw", "my-agent");
     defer allocator.free(logs_dir);
     fs_compat.makePath(logs_dir) catch unreachable;
 
@@ -491,7 +480,7 @@ test "handleGet tails last N lines" {
         try file.writeAll("a\nb\nc\nd\ne\n");
     }
 
-    const resp = handleGet(allocator, p, "nullclaw", "my-agent", 2, .instance);
+    const resp = handleGet(allocator, fixture.paths, "nullclaw", "my-agent", 2, .instance);
     defer allocator.free(resp.body);
 
     const parsed = try std.json.parseFromSlice(
@@ -509,14 +498,10 @@ test "handleGet tails last N lines" {
 
 test "handleStream returns SSE snapshot" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-logs-api-stream";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
-
-    const logs_dir = try p.instanceLogs(allocator, "nullclaw", "my-agent");
+    const logs_dir = try fixture.paths.instanceLogs(allocator, "nullclaw", "my-agent");
     defer allocator.free(logs_dir);
     fs_compat.makePath(logs_dir) catch unreachable;
 
@@ -529,7 +514,7 @@ test "handleStream returns SSE snapshot" {
         try file.writeAll("line-a\nline-b\n");
     }
 
-    const resp = handleStream(allocator, p, "nullclaw", "my-agent", 50, .instance);
+    const resp = handleStream(allocator, fixture.paths, "nullclaw", "my-agent", 50, .instance);
     defer allocator.free(resp.body);
     try std.testing.expectEqualStrings("200 OK", resp.status);
     try std.testing.expectEqualStrings("text/event-stream", resp.content_type);
@@ -540,14 +525,10 @@ test "handleStream returns SSE snapshot" {
 
 test "handleGet separates legacy stdout and nullhub logs by source" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-logs-api-sources";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
-
-    const logs_dir = try p.instanceLogs(allocator, "nullclaw", "my-agent");
+    const logs_dir = try fixture.paths.instanceLogs(allocator, "nullclaw", "my-agent");
     defer allocator.free(logs_dir);
     fs_compat.makePath(logs_dir) catch unreachable;
 
@@ -567,7 +548,7 @@ test "handleGet separates legacy stdout and nullhub logs by source" {
         try file.writeAll("[nullhub/supervisor][2] new diag\n");
     }
 
-    const instance_resp = handleGet(allocator, p, "nullclaw", "my-agent", 100, .instance);
+    const instance_resp = handleGet(allocator, fixture.paths, "nullclaw", "my-agent", 100, .instance);
     defer allocator.free(instance_resp.body);
     const instance_parsed = try std.json.parseFromSlice(
         struct { lines: [][]const u8 },
@@ -580,7 +561,7 @@ test "handleGet separates legacy stdout and nullhub logs by source" {
     try std.testing.expectEqualStrings("app line 1", instance_parsed.value.lines[0]);
     try std.testing.expectEqualStrings("app line 2", instance_parsed.value.lines[1]);
 
-    const nullhub_resp = handleGet(allocator, p, "nullclaw", "my-agent", 100, .nullhub);
+    const nullhub_resp = handleGet(allocator, fixture.paths, "nullclaw", "my-agent", 100, .nullhub);
     defer allocator.free(nullhub_resp.body);
     const nullhub_parsed = try std.json.parseFromSlice(
         struct { lines: [][]const u8 },
@@ -596,14 +577,10 @@ test "handleGet separates legacy stdout and nullhub logs by source" {
 
 test "handleDelete clears selected source while preserving the other" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-logs-api-clear-source";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
-
-    const logs_dir = try p.instanceLogs(allocator, "nullclaw", "my-agent");
+    const logs_dir = try fixture.paths.instanceLogs(allocator, "nullclaw", "my-agent");
     defer allocator.free(logs_dir);
     fs_compat.makePath(logs_dir) catch unreachable;
 
@@ -623,7 +600,7 @@ test "handleDelete clears selected source while preserving the other" {
         try file.writeAll("[nullhub/supervisor][2] dedicated diag\n");
     }
 
-    const clear_nullhub = handleDelete(allocator, p, "nullclaw", "my-agent", .nullhub);
+    const clear_nullhub = handleDelete(allocator, fixture.paths, "nullclaw", "my-agent", .nullhub);
     try std.testing.expectEqualStrings("200 OK", clear_nullhub.status);
 
     {

--- a/src/api/providers.zig
+++ b/src/api/providers.zig
@@ -5,6 +5,7 @@ const paths_mod = @import("../core/paths.zig");
 const helpers = @import("helpers.zig");
 const wizard_api = @import("wizard.zig");
 const query_mod = @import("query.zig");
+const test_helpers = @import("../test_helpers.zig");
 
 const appendEscaped = helpers.appendEscaped;
 
@@ -770,7 +771,10 @@ test "hasRevealParam detects reveal query param" {
 
 test "handleList returns empty array for no providers" {
     const allocator = std.testing.allocator;
-    const path = "/tmp/nullhub-provider-test-list.json";
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
+    defer allocator.free(path);
     var s = state_mod.State.init(allocator, path);
     defer s.deinit();
 
@@ -781,7 +785,10 @@ test "handleList returns empty array for no providers" {
 
 test "handleList masks api_key by default" {
     const allocator = std.testing.allocator;
-    const path = "/tmp/nullhub-provider-test-mask.json";
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
+    defer allocator.free(path);
     var s = state_mod.State.init(allocator, path);
     defer s.deinit();
 
@@ -796,7 +803,10 @@ test "handleList masks api_key by default" {
 
 test "handleList reveals api_key when requested" {
     const allocator = std.testing.allocator;
-    const path = "/tmp/nullhub-provider-test-reveal.json";
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
+    defer allocator.free(path);
     var s = state_mod.State.init(allocator, path);
     defer s.deinit();
 
@@ -809,7 +819,10 @@ test "handleList reveals api_key when requested" {
 
 test "handleList includes base_url for openai-compatible provider" {
     const allocator = std.testing.allocator;
-    const path = "/tmp/nullhub-provider-test-baseurl.json";
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
+    defer allocator.free(path);
     var s = state_mod.State.init(allocator, path);
     defer s.deinit();
 
@@ -828,7 +841,10 @@ test "handleList includes base_url for openai-compatible provider" {
 
 test "handleList includes empty base_url for standard provider" {
     const allocator = std.testing.allocator;
-    const path = "/tmp/nullhub-provider-test-baseurl-empty.json";
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
+    defer allocator.free(path);
     var s = state_mod.State.init(allocator, path);
     defer s.deinit();
 
@@ -841,7 +857,10 @@ test "handleList includes empty base_url for standard provider" {
 
 test "findProviderProbeComponent prefers installed nullclaw" {
     const allocator = std.testing.allocator;
-    const path = "/tmp/nullhub-provider-test-probe-component.json";
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
+    defer allocator.free(path);
     var s = state_mod.State.init(allocator, path);
     defer s.deinit();
 
@@ -854,7 +873,10 @@ test "findProviderProbeComponent prefers installed nullclaw" {
 
 test "findProviderProbeComponent returns null without nullclaw instances" {
     const allocator = std.testing.allocator;
-    const path = "/tmp/nullhub-provider-test-probe-component-empty.json";
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
+    defer allocator.free(path);
     var s = state_mod.State.init(allocator, path);
     defer s.deinit();
 
@@ -865,12 +887,9 @@ test "findProviderProbeComponent returns null without nullclaw instances" {
 
 test "handleDelete removes provider" {
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-provider-test-delete";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    std_compat.fs.makeDirAbsolute(tmp) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-
-    const path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
     defer allocator.free(path);
 
     var s = state_mod.State.init(allocator, path);
@@ -886,7 +905,10 @@ test "handleDelete removes provider" {
 
 test "handleDelete returns error for unknown id" {
     const allocator = std.testing.allocator;
-    const path = "/tmp/nullhub-provider-test-del-unknown.json";
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const path = try fixture.paths.state(allocator);
+    defer allocator.free(path);
     var s = state_mod.State.init(allocator, path);
     defer s.deinit();
 
@@ -928,24 +950,19 @@ test "handleCreate with base_url saves without requiring nullclaw probe" {
     // nullclaw probe — the probe is designed for known providers and can
     // misclassify valid responses from arbitrary OpenAI-compatible endpoints.
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-provider-test-custom-create";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    std_compat.fs.makeDirAbsolute(tmp) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-
-    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
     defer allocator.free(state_path);
 
     var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     // No nullclaw instance installed — would normally block standard providers
-    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
-
     const body =
         \\{"provider":"local-llm","api_key":"sk-test","model":"llama3","base_url":"http://127.0.0.1:19999/v1"}
     ;
-    const json = try handleCreate(allocator, body, &s, paths);
+    const json = try handleCreate(allocator, body, &s, fixture.paths);
     defer allocator.free(json);
 
     try std.testing.expect(std.mem.indexOf(u8, json, "\"error\"") == null);
@@ -956,23 +973,19 @@ test "handleCreate with base_url saves without requiring nullclaw probe" {
 
 test "handleCreate with base_url persists custom provider" {
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-provider-test-custom-create-persist";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    std_compat.fs.makeDirAbsolute(tmp) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-
-    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
     defer allocator.free(state_path);
 
     {
         var s = state_mod.State.init(allocator, state_path);
         defer s.deinit();
 
-        const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
         const body =
             \\{"provider":"local-llm","api_key":"sk-test","model":"llama3","base_url":"http://127.0.0.1:5801/v1"}
         ;
-        const json = try handleCreate(allocator, body, &s, paths);
+        const json = try handleCreate(allocator, body, &s, fixture.paths);
         defer allocator.free(json);
 
         try std.testing.expect(std.mem.indexOf(u8, json, "\"error\"") == null);
@@ -991,24 +1004,19 @@ test "handleCreate without base_url requires nullclaw instance" {
     // Standard providers (no base_url) must require an installed nullclaw
     // instance to run the probe.
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-provider-test-standard-create";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    std_compat.fs.makeDirAbsolute(tmp) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-
-    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
     defer allocator.free(state_path);
 
     var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     // No nullclaw instance installed
-    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
-
     const body =
         \\{"provider":"openrouter","api_key":"sk-or-test"}
     ;
-    const json = try handleCreate(allocator, body, &s, paths);
+    const json = try handleCreate(allocator, body, &s, fixture.paths);
     defer allocator.free(json);
 
     try std.testing.expect(std.mem.indexOf(u8, json, "\"error\"") != null);
@@ -1021,12 +1029,9 @@ test "handleValidate for custom provider uses models probe (not nullclaw)" {
     // (no server at 19999) but the key point is we get a live_ok + reason response,
     // NOT the old "custom endpoint — validation via /models not yet available" placeholder.
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-provider-test-validate-custom";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    std_compat.fs.makeDirAbsolute(tmp) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-
-    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
     defer allocator.free(state_path);
 
     var s = state_mod.State.init(allocator, state_path);
@@ -1038,8 +1043,7 @@ test "handleValidate for custom provider uses models probe (not nullclaw)" {
         .base_url = "http://127.0.0.1:19999/v1",
     });
 
-    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
-    const json = try handleValidate(allocator, 1, &s, paths);
+    const json = try handleValidate(allocator, 1, &s, fixture.paths);
     defer allocator.free(json);
 
     // Must return a probe result (live_ok present), never the old placeholder string.
@@ -1133,23 +1137,18 @@ test "handleCreate custom provider records last_validation_at after probe attemp
     // When a custom provider is created, a /models probe is attempted. Even if it
     // fails (no server), last_validation_at must be set in the saved state.
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-provider-test-custom-create-ts";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    std_compat.fs.makeDirAbsolute(tmp) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-
-    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
     defer allocator.free(state_path);
 
     var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
-    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
-
     const body =
         \\{"provider":"local-llm","api_key":"sk-test","model":"llama3","base_url":"http://127.0.0.1:19998/v1"}
     ;
-    const json = try handleCreate(allocator, body, &s, paths);
+    const json = try handleCreate(allocator, body, &s, fixture.paths);
     defer allocator.free(json);
 
     // Must save successfully (no error)
@@ -1177,21 +1176,19 @@ fn makeInstanceDir(tmp: []const u8) !void {
 
 test "syncProviderToInstances writes provider creds into instance config" {
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-sync-test-write";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    std_compat.fs.makeDirAbsolute(tmp) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    const state_path = try fixture.paths.state(allocator);
     defer allocator.free(state_path);
     var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     try s.addInstance("nullclaw", "default", .{ .version = "v2026.1.0" });
 
-    try makeInstanceDir(tmp);
+    try makeInstanceDir(fixture.root);
 
     // Write an existing config with an unrelated key
-    const config_path = try std.fmt.allocPrint(allocator, "{s}/instances/nullclaw/default/config.json", .{tmp});
+    const config_path = try fixture.paths.instanceConfig(allocator, "nullclaw", "default");
     defer allocator.free(config_path);
     {
         const f = try std_compat.fs.createFileAbsolute(config_path, .{});
@@ -1199,8 +1196,7 @@ test "syncProviderToInstances writes provider creds into instance config" {
         try f.writeAll("{\"port\":9100}\n");
     }
 
-    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
-    syncProviderToInstances(allocator, &s, paths, "custom-llm", "sk-abc123", "https://example.com/v1");
+    syncProviderToInstances(allocator, &s, fixture.paths, "custom-llm", "sk-abc123", "https://example.com/v1");
 
     // Read back and verify credentials are present
     const f2 = try std_compat.fs.openFileAbsolute(config_path, .{});
@@ -1217,20 +1213,18 @@ test "syncProviderToInstances writes provider creds into instance config" {
 
 test "syncProviderToInstances omits base_url when empty" {
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-sync-test-no-baseurl";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    std_compat.fs.makeDirAbsolute(tmp) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    const state_path = try fixture.paths.state(allocator);
     defer allocator.free(state_path);
     var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     try s.addInstance("nullclaw", "default", .{ .version = "v2026.1.0" });
 
-    try makeInstanceDir(tmp);
+    try makeInstanceDir(fixture.root);
 
-    const config_path = try std.fmt.allocPrint(allocator, "{s}/instances/nullclaw/default/config.json", .{tmp});
+    const config_path = try fixture.paths.instanceConfig(allocator, "nullclaw", "default");
     defer allocator.free(config_path);
     {
         const f = try std_compat.fs.createFileAbsolute(config_path, .{});
@@ -1238,8 +1232,7 @@ test "syncProviderToInstances omits base_url when empty" {
         try f.writeAll("{}\n");
     }
 
-    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
-    syncProviderToInstances(allocator, &s, paths, "openrouter", "sk-or-key", "");
+    syncProviderToInstances(allocator, &s, fixture.paths, "openrouter", "sk-or-key", "");
 
     const f2 = try std_compat.fs.openFileAbsolute(config_path, .{});
     defer f2.close();
@@ -1254,20 +1247,18 @@ test "syncProviderToInstances omits base_url when empty" {
 
 test "syncProviderToInstances removes stale base_url when empty" {
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-sync-test-clear-baseurl";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    std_compat.fs.makeDirAbsolute(tmp) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    const state_path = try fixture.paths.state(allocator);
     defer allocator.free(state_path);
     var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     try s.addInstance("nullclaw", "default", .{ .version = "v2026.1.0" });
 
-    try makeInstanceDir(tmp);
+    try makeInstanceDir(fixture.root);
 
-    const config_path = try std.fmt.allocPrint(allocator, "{s}/instances/nullclaw/default/config.json", .{tmp});
+    const config_path = try fixture.paths.instanceConfig(allocator, "nullclaw", "default");
     defer allocator.free(config_path);
     {
         const f = try std_compat.fs.createFileAbsolute(config_path, .{});
@@ -1275,8 +1266,7 @@ test "syncProviderToInstances removes stale base_url when empty" {
         try f.writeAll("{\"models\":{\"providers\":{\"openrouter\":{\"api_key\":\"old\",\"base_url\":\"https://old.example.com/v1\"}}}}\n");
     }
 
-    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
-    syncProviderToInstances(allocator, &s, paths, "openrouter", "sk-or-key", "");
+    syncProviderToInstances(allocator, &s, fixture.paths, "openrouter", "sk-or-key", "");
 
     const f2 = try std_compat.fs.openFileAbsolute(config_path, .{});
     defer f2.close();
@@ -1290,30 +1280,24 @@ test "syncProviderToInstances removes stale base_url when empty" {
 
 test "syncProviderToInstances is no-op when no nullclaw instances" {
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-sync-test-noop";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    std_compat.fs.makeDirAbsolute(tmp) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    const state_path = try fixture.paths.state(allocator);
     defer allocator.free(state_path);
     var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
     // No nullclaw instances registered
 
-    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
     // Should not panic or error when there are no instances
-    syncProviderToInstances(allocator, &s, paths, "openrouter", "sk-key", "");
+    syncProviderToInstances(allocator, &s, fixture.paths, "openrouter", "sk-key", "");
 }
 
 test "handleUpdate custom provider clears stale validation metadata" {
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-provider-test-update-custom-clears-validation";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    std_compat.fs.makeDirAbsolute(tmp) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-
-    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
     defer allocator.free(state_path);
 
     var s = state_mod.State.init(allocator, state_path);
@@ -1331,8 +1315,7 @@ test "handleUpdate custom provider clears stale validation metadata" {
         .last_validation_ok = true,
     });
 
-    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
-    const json = try handleUpdate(allocator, 1, "{\"api_key\":\"new-key\"}", &s, paths);
+    const json = try handleUpdate(allocator, 1, "{\"api_key\":\"new-key\"}", &s, fixture.paths);
     defer allocator.free(json);
 
     const provider = s.getSavedProvider(1).?;

--- a/src/api/status.zig
+++ b/src/api/status.zig
@@ -7,6 +7,7 @@ const paths_mod = @import("../core/paths.zig");
 const helpers = @import("helpers.zig");
 const access = @import("../access.zig");
 const version = @import("../version.zig");
+const test_helpers = @import("../test_helpers.zig");
 
 const ApiResponse = helpers.ApiResponse;
 const appendEscaped = helpers.appendEscaped;
@@ -282,11 +283,13 @@ fn buildStatusJson(buf: *std.array_list.Managed(u8), s: *state_mod.State, manage
 
 test "handleStatus returns valid JSON with hub version" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-status-api.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
-    var p = try paths_mod.Paths.init(allocator, "/tmp/nullhub-test-status-api");
-    defer p.deinit(allocator);
-    var mgr = manager_mod.Manager.init(allocator, p);
+    var mgr = manager_mod.Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const resp = handleStatus(allocator, &s, &mgr, 3600, access.default_bind_host, access.default_port, .{});
@@ -347,11 +350,13 @@ test "handleStatus returns valid JSON with hub version" {
 
 test "handleStatus includes instances" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-status-api.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
-    var p = try paths_mod.Paths.init(allocator, "/tmp/nullhub-test-status-api");
-    defer p.deinit(allocator);
-    var mgr = manager_mod.Manager.init(allocator, p);
+    var mgr = manager_mod.Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "2026.3.1", .auto_start = true });
@@ -412,11 +417,13 @@ test "handleStatus includes instances" {
 
 test "handleStatus overall_status becomes error when a component has failed instances" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-status-api.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
-    var p = try paths_mod.Paths.init(allocator, "/tmp/nullhub-test-status-api");
-    defer p.deinit(allocator);
-    var mgr = manager_mod.Manager.init(allocator, p);
+    var mgr = manager_mod.Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     try s.addInstance("nullclaw", "broken", .{ .version = "1.0.0" });
@@ -438,11 +445,13 @@ test "handleStatus overall_status becomes error when a component has failed inst
 
 test "handleStatus includes launch_mode" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-status-api.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
-    var p = try paths_mod.Paths.init(allocator, "/tmp/nullhub-test-status-api");
-    defer p.deinit(allocator);
-    var mgr = manager_mod.Manager.init(allocator, p);
+    var mgr = manager_mod.Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0", .launch_mode = "agent" });
@@ -456,11 +465,13 @@ test "handleStatus includes launch_mode" {
 
 test "handleStatus includes verbose flag" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-status-api.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
-    var p = try paths_mod.Paths.init(allocator, "/tmp/nullhub-test-status-api");
-    defer p.deinit(allocator);
-    var mgr = manager_mod.Manager.init(allocator, p);
+    var mgr = manager_mod.Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0", .verbose = true });
@@ -474,11 +485,13 @@ test "handleStatus includes verbose flag" {
 
 test "handleStatus with empty state returns empty instances" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-status-api.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
-    var p = try paths_mod.Paths.init(allocator, "/tmp/nullhub-test-status-api");
-    defer p.deinit(allocator);
-    var mgr = manager_mod.Manager.init(allocator, p);
+    var mgr = manager_mod.Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const resp = handleStatus(allocator, &s, &mgr, 42, access.default_bind_host, access.default_port, .{});

--- a/src/api/updates.zig
+++ b/src/api/updates.zig
@@ -9,6 +9,7 @@ const downloader = @import("../installer/downloader.zig");
 const launch_args_mod = @import("../core/launch_args.zig");
 const platform = @import("../core/platform.zig");
 const helpers = @import("helpers.zig");
+const test_helpers = @import("../test_helpers.zig");
 
 const ApiResponse = helpers.ApiResponse;
 const appendEscaped = helpers.appendEscaped;
@@ -286,7 +287,11 @@ fn buildApplyJson(buf: *std.array_list.Managed(u8), component: []const u8, name:
 
 test "handleCheckUpdates with empty state returns empty updates array" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-updates-api.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     const resp = handleCheckUpdates(allocator, &s);
@@ -299,7 +304,11 @@ test "handleCheckUpdates with empty state returns empty updates array" {
 
 test "handleCheckUpdates with instances returns correct structure" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-updates-api.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "2026.3.1", .auto_start = true });
@@ -337,7 +346,11 @@ test "handleCheckUpdates with instances returns correct structure" {
 
 test "handleApplyUpdate returns 404 for missing instance" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-updates-api.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     const resp = handleApplyUpdate(allocator, &s, "nonexistent", "nope");
@@ -347,7 +360,11 @@ test "handleApplyUpdate returns 404 for missing instance" {
 
 test "handleApplyUpdate returns success for existing instance" {
     const allocator = std.testing.allocator;
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-test-updates-api.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "2026.3.1", .auto_start = false });

--- a/src/api/wizard.zig
+++ b/src/api/wizard.zig
@@ -16,6 +16,7 @@ const manager_mod = @import("../supervisor/manager.zig");
 const integration_mod = @import("../core/integration.zig");
 const providers_api = @import("providers.zig");
 const query = @import("query.zig");
+const test_helpers = @import("../test_helpers.zig");
 
 const appendEscaped = helpers.appendEscaped;
 pub const ProviderProbeResult = struct {
@@ -1078,15 +1079,11 @@ test "compareVersionTags compares numeric version segments" {
 
 test "findInstalledComponentBinary finds binary in bin directory" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-find-installed-binary";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    try fixture.paths.ensureDirs();
 
-    var paths = try paths_mod.Paths.init(allocator, tmp_root);
-    defer paths.deinit(allocator);
-    try paths.ensureDirs();
-
-    const bin_path = try paths.binary(allocator, "nullboiler", "v1.2.3");
+    const bin_path = try fixture.paths.binary(allocator, "nullboiler", "v1.2.3");
     defer allocator.free(bin_path);
 
     {
@@ -1095,7 +1092,7 @@ test "findInstalledComponentBinary finds binary in bin directory" {
         try file.writeAll("#!/bin/sh\n");
     }
 
-    const found = findInstalledComponentBinary(allocator, "nullboiler", paths);
+    const found = findInstalledComponentBinary(allocator, "nullboiler", fixture.paths);
     try std.testing.expect(found != null);
     defer allocator.free(found.?);
     try std.testing.expectEqualStrings(bin_path, found.?);
@@ -1103,38 +1100,40 @@ test "findInstalledComponentBinary finds binary in bin directory" {
 
 test "handleGetWizard returns null for unknown component" {
     const allocator = std.testing.allocator;
-    const paths = paths_mod.Paths.init(allocator, "/tmp/nullhub-test-wizard-get") catch @panic("Paths.init");
-    defer paths.deinit(allocator);
-    var state = state_mod.State.init(allocator, "/tmp/nullhub-test-wizard-get/state.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var state = state_mod.State.init(allocator, state_path);
     defer state.deinit();
-    const result = handleGetWizard(allocator, "nonexistent", paths, &state);
+    const result = handleGetWizard(allocator, "nonexistent", fixture.paths, &state);
     try std.testing.expect(result == null);
 }
 
 test "handleGetWizard returns null when no binary found" {
     const allocator = std.testing.allocator;
-    const paths = paths_mod.Paths.init(allocator, "/tmp/nullhub-test-wizard-nobin") catch @panic("Paths.init");
-    defer paths.deinit(allocator);
-    var state = state_mod.State.init(allocator, "/tmp/nullhub-test-wizard-nobin/state.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var state = state_mod.State.init(allocator, state_path);
     defer state.deinit();
     // nullclaw is a known component but there's no binary in test dirs
-    const result = handleGetWizard(allocator, "nullclaw", paths, &state);
+    const result = handleGetWizard(allocator, "nullclaw", fixture.paths, &state);
     try std.testing.expect(result == null);
 }
 
 test "prepareWizardBody injects tracker settings for nullboiler" {
     const allocator = std.testing.allocator;
-    var paths = paths_mod.Paths.init(allocator, "/tmp/nullhub-test-wizard-prepare") catch @panic("Paths.init");
-    defer paths.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    fixture.paths.ensureDirs() catch @panic("ensureDirs");
 
-    std_compat.fs.deleteTreeAbsolute(paths.root) catch {};
-    paths.ensureDirs() catch @panic("ensureDirs");
-
-    const inst_dir = paths.instanceDir(allocator, "nulltickets", "tracker-a") catch @panic("instanceDir");
+    const inst_dir = fixture.paths.instanceDir(allocator, "nulltickets", "tracker-a") catch @panic("instanceDir");
     defer allocator.free(inst_dir);
     std.fs.makePathAbsolute(inst_dir) catch @panic("makePathAbsolute");
 
-    const config_path = paths.instanceConfig(allocator, "nulltickets", "tracker-a") catch @panic("instanceConfig");
+    const config_path = fixture.paths.instanceConfig(allocator, "nulltickets", "tracker-a") catch @panic("instanceConfig");
     defer allocator.free(config_path);
     {
         const file = std_compat.fs.createFileAbsolute(config_path, .{ .truncate = true }) catch @panic("createFileAbsolute");
@@ -1146,7 +1145,7 @@ test "prepareWizardBody injects tracker settings for nullboiler" {
         allocator,
         "nullboiler",
         "{\"instance_name\":\"worker-a\",\"tracker_instance\":\"tracker-a\"}",
-        paths,
+        fixture.paths,
     ) orelse @panic("prepareWizardBody");
     defer allocator.free(rendered);
 
@@ -1165,29 +1164,33 @@ test "prepareWizardBody injects tracker settings for nullboiler" {
 
 test "handlePostWizard returns null for unknown component" {
     const allocator = std.testing.allocator;
-    var paths = paths_mod.Paths.init(allocator, "/tmp/nullhub-test-wizard-post2") catch @panic("Paths.init");
-    defer paths.deinit(allocator);
-    var state = state_mod.State.init(allocator, "/tmp/nullhub-test-wizard-post2/state.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var state = state_mod.State.init(allocator, state_path);
     defer state.deinit();
-    var mgr = manager_mod.Manager.init(allocator, paths);
+    var mgr = manager_mod.Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const body = "{\"instance_name\":\"my-agent\",\"version\":\"latest\"}";
-    const result = handlePostWizard(allocator, "nonexistent", body, paths, &state, &mgr);
+    const result = handlePostWizard(allocator, "nonexistent", body, fixture.paths, &state, &mgr);
     try std.testing.expect(result == null);
 }
 
 test "handlePostWizard returns error for known component without binary" {
     const allocator = std.testing.allocator;
-    var paths = paths_mod.Paths.init(allocator, "/tmp/nullhub-test-wizard-post3") catch @panic("Paths.init");
-    defer paths.deinit(allocator);
-    var state = state_mod.State.init(allocator, "/tmp/nullhub-test-wizard-post3/state.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var state = state_mod.State.init(allocator, state_path);
     defer state.deinit();
-    var mgr = manager_mod.Manager.init(allocator, paths);
+    var mgr = manager_mod.Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const body = "{\"instance_name\":\"my-agent\",\"version\":\"latest\"}";
-    const json = handlePostWizard(allocator, "nullclaw", body, paths, &state, &mgr);
+    const json = handlePostWizard(allocator, "nullclaw", body, fixture.paths, &state, &mgr);
     // In test environment, orchestrator.install will fail, so we get an error JSON
     try std.testing.expect(json != null);
     defer allocator.free(json.?);
@@ -1214,22 +1217,18 @@ test "extractComponentName parses validate-providers path" {
 
 test "handleValidateProviders skips probe for custom base_url and saves provider" {
     const allocator = std.testing.allocator;
-    const tmp = "/tmp/nullhub-wizard-test-custom-provider";
-    std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-    std_compat.fs.makeDirAbsolute(tmp) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp) catch {};
-
-    const state_path = try std.fmt.allocPrint(allocator, "{s}/state.json", .{tmp});
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
     defer allocator.free(state_path);
 
     var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
-    const paths = paths_mod.Paths.init(allocator, tmp) catch @panic("Paths.init");
     const body =
         \\{"providers":[{"provider":"local-llm","api_key":"sk-test","model":"llama3","base_url":"http://127.0.0.1:5801/v1"}]}
     ;
-    const json = handleValidateProviders(allocator, "nullclaw", body, paths, &s) orelse @panic("expected response");
+    const json = handleValidateProviders(allocator, "nullclaw", body, fixture.paths, &s) orelse @panic("expected response");
     defer allocator.free(json);
 
     try std.testing.expect(std.mem.indexOf(u8, json, "\"live_ok\":true") != null);

--- a/src/core/nullclaw_web_channel.zig
+++ b/src/core/nullclaw_web_channel.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const std_compat = @import("compat");
 const paths_mod = @import("paths.zig");
 const state_mod = @import("state.zig");
+const test_helpers = @import("../test_helpers.zig");
 
 const MAX_CONFIG_BYTES = 8 * 1024 * 1024;
 const DEFAULT_WEB_PORT_START: u16 = 32123;
@@ -260,15 +261,13 @@ fn writeAbsolute(path: []const u8, content: []const u8) !void {
 
 test "ensureNullclawWebChannelConfig injects web channel when missing" {
     const allocator = std.testing.allocator;
-    const root = "/tmp/nullhub-test-web-channel-missing";
-    std_compat.fs.deleteTreeAbsolute(root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(root) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    try fixture.paths.ensureDirs();
 
-    var paths = try paths_mod.Paths.init(allocator, root);
-    defer paths.deinit();
-    try paths.ensureDirs();
-
-    var state = state_mod.State.init(allocator, "/tmp/nullhub-test-web-channel-missing/state.json");
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var state = state_mod.State.init(allocator, state_path);
     defer state.deinit();
 
     try state.addInstance("nullclaw", "instance-1", .{
@@ -277,11 +276,11 @@ test "ensureNullclawWebChannelConfig injects web channel when missing" {
         .launch_mode = "gateway",
     });
 
-    const inst_dir = try paths.instanceDir(allocator, "nullclaw", "instance-1");
+    const inst_dir = try fixture.paths.instanceDir(allocator, "nullclaw", "instance-1");
     defer allocator.free(inst_dir);
     try std_compat.fs.makeDirAbsolute(inst_dir);
 
-    const cfg_path = try paths.instanceConfig(allocator, "nullclaw", "instance-1");
+    const cfg_path = try fixture.paths.instanceConfig(allocator, "nullclaw", "instance-1");
     defer allocator.free(cfg_path);
     try writeAbsolute(cfg_path,
         \\{
@@ -292,7 +291,7 @@ test "ensureNullclawWebChannelConfig injects web channel when missing" {
         \\}
     );
 
-    const result = try ensureNullclawWebChannelConfig(allocator, paths, &state, "nullclaw", "instance-1");
+    const result = try ensureNullclawWebChannelConfig(allocator, fixture.paths, &state, "nullclaw", "instance-1");
     try std.testing.expect(result.changed);
     try std.testing.expect(result.web_port != null);
 
@@ -309,15 +308,13 @@ test "ensureNullclawWebChannelConfig injects web channel when missing" {
 
 test "ensureNullclawWebChannelConfig picks next free port among instances" {
     const allocator = std.testing.allocator;
-    const root = "/tmp/nullhub-test-web-channel-port-pick";
-    std_compat.fs.deleteTreeAbsolute(root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(root) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    try fixture.paths.ensureDirs();
 
-    var paths = try paths_mod.Paths.init(allocator, root);
-    defer paths.deinit();
-    try paths.ensureDirs();
-
-    var state = state_mod.State.init(allocator, "/tmp/nullhub-test-web-channel-port-pick/state.json");
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var state = state_mod.State.init(allocator, state_path);
     defer state.deinit();
 
     try state.addInstance("nullclaw", "default", .{
@@ -331,11 +328,11 @@ test "ensureNullclawWebChannelConfig picks next free port among instances" {
         .launch_mode = "gateway",
     });
 
-    const default_dir = try paths.instanceDir(allocator, "nullclaw", "default");
+    const default_dir = try fixture.paths.instanceDir(allocator, "nullclaw", "default");
     defer allocator.free(default_dir);
     try std_compat.fs.makeDirAbsolute(default_dir);
 
-    const default_cfg = try paths.instanceConfig(allocator, "nullclaw", "default");
+    const default_cfg = try fixture.paths.instanceConfig(allocator, "nullclaw", "default");
     defer allocator.free(default_cfg);
     try writeAbsolute(default_cfg,
         \\{
@@ -351,11 +348,11 @@ test "ensureNullclawWebChannelConfig picks next free port among instances" {
         \\}
     );
 
-    const inst_dir = try paths.instanceDir(allocator, "nullclaw", "instance-2");
+    const inst_dir = try fixture.paths.instanceDir(allocator, "nullclaw", "instance-2");
     defer allocator.free(inst_dir);
     try std_compat.fs.makeDirAbsolute(inst_dir);
 
-    const inst_cfg = try paths.instanceConfig(allocator, "nullclaw", "instance-2");
+    const inst_cfg = try fixture.paths.instanceConfig(allocator, "nullclaw", "instance-2");
     defer allocator.free(inst_cfg);
     try writeAbsolute(inst_cfg,
         \\{
@@ -365,7 +362,7 @@ test "ensureNullclawWebChannelConfig picks next free port among instances" {
         \\}
     );
 
-    const result = try ensureNullclawWebChannelConfig(allocator, paths, &state, "nullclaw", "instance-2");
+    const result = try ensureNullclawWebChannelConfig(allocator, fixture.paths, &state, "nullclaw", "instance-2");
     try std.testing.expect(result.changed);
     try std.testing.expectEqual(@as(?u16, 32124), result.web_port);
 }

--- a/src/discovery.zig
+++ b/src/discovery.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const manifest_mod = @import("core/manifest.zig");
 const state_mod = @import("core/state.zig");
+const test_helpers = @import("test_helpers.zig");
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -140,7 +141,11 @@ test "findConnections: empty state returns empty list" {
     };
     const m = testManifest(&specs);
 
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-discovery-test.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     const connections = try findConnections(allocator, m, &s);
@@ -157,7 +162,11 @@ test "findConnections: matching instance returns connection" {
     };
     const m = testManifest(&specs);
 
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-discovery-test.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     try s.addInstance("nullboiler", "default", .{ .version = "1.0.0" });
@@ -179,7 +188,11 @@ test "findConnections: no matching component returns empty" {
     };
     const m = testManifest(&specs);
 
-    var s = state_mod.State.init(allocator, "/tmp/nullhub-discovery-test.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
 
     // Add an instance of a different component.

--- a/src/installer/orchestrator.zig
+++ b/src/installer/orchestrator.zig
@@ -15,6 +15,7 @@ const nullclaw_web_channel = @import("../core/nullclaw_web_channel.zig");
 const manager_mod = @import("../supervisor/manager.zig");
 const ui_modules_mod = @import("ui_modules.zig");
 const managed_skills = @import("../managed_skills.zig");
+const test_helpers = @import("../test_helpers.zig");
 const MAX_CONFIG_BYTES = 4 * 1024 * 1024;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -898,32 +899,28 @@ test "writeFile creates file with correct content" {
 
 test "directory creation succeeds in temp directory" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/test-orchestrator-dirs";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
     // Create top-level dirs
-    try p.ensureDirs();
+    try fixture.paths.ensureDirs();
 
     // Create component dir
-    const comp_dir = try std.fs.path.join(allocator, &.{ p.root, "instances", "testcomp" });
+    const comp_dir = try std.fs.path.join(allocator, &.{ fixture.paths.root, "instances", "testcomp" });
     defer allocator.free(comp_dir);
     try std_compat.fs.makeDirAbsolute(comp_dir);
 
     // Create instance dir
-    const inst_dir = try p.instanceDir(allocator, "testcomp", "myinst");
+    const inst_dir = try fixture.paths.instanceDir(allocator, "testcomp", "myinst");
     defer allocator.free(inst_dir);
     try std_compat.fs.makeDirAbsolute(inst_dir);
 
     // Create data and logs subdirs
-    const data_dir = try p.instanceData(allocator, "testcomp", "myinst");
+    const data_dir = try fixture.paths.instanceData(allocator, "testcomp", "myinst");
     defer allocator.free(data_dir);
     try std_compat.fs.makeDirAbsolute(data_dir);
 
-    const logs_dir = try p.instanceLogs(allocator, "testcomp", "myinst");
+    const logs_dir = try fixture.paths.instanceLogs(allocator, "testcomp", "myinst");
     defer allocator.free(logs_dir);
     try std_compat.fs.makeDirAbsolute(logs_dir);
 

--- a/src/installer/orchestrator.zig
+++ b/src/installer/orchestrator.zig
@@ -1089,11 +1089,13 @@ fn writeFile(path: []const u8, content: []const u8) !void {
 
 test "install returns UnknownComponent for unknown component" {
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-orchestrator");
-    defer p.deinit(allocator);
-    var s = state_mod.State.init(allocator, "/tmp/test-orchestrator/state.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
-    var mgr = manager_mod.Manager.init(allocator, p);
+    var mgr = manager_mod.Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const result = install(allocator, .{
@@ -1101,17 +1103,19 @@ test "install returns UnknownComponent for unknown component" {
         .instance_name = "test",
         .version = "latest",
         .answers_json = "{}",
-    }, p, &s, &mgr);
+    }, fixture.paths, &s, &mgr);
     try std.testing.expectError(error.UnknownComponent, result);
 }
 
 test "install returns FetchFailed for known component (no network)" {
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-orchestrator-fetch");
-    defer p.deinit(allocator);
-    var s = state_mod.State.init(allocator, "/tmp/test-orchestrator-fetch/state.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
-    var mgr = manager_mod.Manager.init(allocator, p);
+    var mgr = manager_mod.Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const result = install(allocator, .{
@@ -1119,18 +1123,20 @@ test "install returns FetchFailed for known component (no network)" {
         .instance_name = "test",
         .version = "latest",
         .answers_json = "{}",
-    }, p, &s, &mgr);
+    }, fixture.paths, &s, &mgr);
     // In test env, GitHub fetch will fail
     try std.testing.expectError(error.FetchFailed, result);
 }
 
 test "install returns InstanceExists for duplicate instance name" {
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-orchestrator-duplicate");
-    defer p.deinit(allocator);
-    var s = state_mod.State.init(allocator, "/tmp/test-orchestrator-duplicate/state.json");
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var s = state_mod.State.init(allocator, state_path);
     defer s.deinit();
-    var mgr = manager_mod.Manager.init(allocator, p);
+    var mgr = manager_mod.Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     try s.addInstance("nullclaw", "instance-1", .{
@@ -1144,41 +1150,45 @@ test "install returns InstanceExists for duplicate instance name" {
         .instance_name = "instance-1",
         .version = "latest",
         .answers_json = "{}",
-    }, p, &s, &mgr);
+    }, fixture.paths, &s, &mgr);
     try std.testing.expectError(error.InstanceExists, result);
 }
 
 test "resolveConfiguredPort reads top-level port" {
-    var paths = try paths_mod.Paths.init(std.testing.allocator, "/tmp/test-orchestrator-port-top");
-    defer paths.deinit(std.testing.allocator);
-    var state = state_mod.State.init(std.testing.allocator, "/tmp/test-orchestrator-port-top-state.json");
+    const allocator = std.testing.allocator;
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var state = state_mod.State.init(allocator, state_path);
     defer state.deinit();
 
-    const port = resolveConfiguredPort(std.testing.allocator, "{\"port\":9001}", 8080, paths, &state);
+    const port = resolveConfiguredPort(allocator, "{\"port\":9001}", 8080, fixture.paths, &state);
     try std.testing.expectEqual(@as(u16, 9001), port);
 }
 
 test "resolveConfiguredPort reads nested answers port" {
-    var paths = try paths_mod.Paths.init(std.testing.allocator, "/tmp/test-orchestrator-port-nested");
-    defer paths.deinit(std.testing.allocator);
-    var state = state_mod.State.init(std.testing.allocator, "/tmp/test-orchestrator-port-nested-state.json");
+    const allocator = std.testing.allocator;
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var state = state_mod.State.init(allocator, state_path);
     defer state.deinit();
 
-    const port = resolveConfiguredPort(std.testing.allocator, "{\"answers\":{\"port\":9101}}", 8080, paths, &state);
+    const port = resolveConfiguredPort(allocator, "{\"answers\":{\"port\":9101}}", 8080, fixture.paths, &state);
     try std.testing.expectEqual(@as(u16, 9101), port);
 }
 
 test "resolveConfiguredPort skips configured instance ports" {
     const allocator = std.testing.allocator;
-    const root = "/tmp/test-orchestrator-port-used";
-    std_compat.fs.deleteTreeAbsolute(root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(root) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
+    try fixture.paths.ensureDirs();
 
-    var paths = try paths_mod.Paths.init(allocator, root);
-    defer paths.deinit(allocator);
-    try paths.ensureDirs();
-
-    var state = state_mod.State.init(allocator, "/tmp/test-orchestrator-port-used-state.json");
+    const state_path = try fixture.paths.state(allocator);
+    defer allocator.free(state_path);
+    var state = state_mod.State.init(allocator, state_path);
     defer state.deinit();
     try state.addInstance("nullclaw", "instance-1", .{
         .version = "v2026.3.8",
@@ -1186,24 +1196,24 @@ test "resolveConfiguredPort skips configured instance ports" {
         .launch_mode = "gateway",
     });
 
-    const comp_dir = try std.fs.path.join(allocator, &.{ root, "instances", "nullclaw" });
+    const comp_dir = try std.fs.path.join(allocator, &.{ fixture.paths.root, "instances", "nullclaw" });
     defer allocator.free(comp_dir);
     std_compat.fs.makeDirAbsolute(comp_dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
         else => return err,
     };
-    const inst_dir = try paths.instanceDir(allocator, "nullclaw", "instance-1");
+    const inst_dir = try fixture.paths.instanceDir(allocator, "nullclaw", "instance-1");
     defer allocator.free(inst_dir);
     std_compat.fs.makeDirAbsolute(inst_dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
         else => return err,
     };
 
-    const config_path = try paths.instanceConfig(allocator, "nullclaw", "instance-1");
+    const config_path = try fixture.paths.instanceConfig(allocator, "nullclaw", "instance-1");
     defer allocator.free(config_path);
     try writeFile(config_path, "{\"gateway\":{\"port\":43000}}");
 
-    const port = resolveConfiguredPort(allocator, "{\"foo\":\"bar\"}", 43000, paths, &state);
+    const port = resolveConfiguredPort(allocator, "{\"foo\":\"bar\"}", 43000, fixture.paths, &state);
     try std.testing.expect(port > 43000);
 }
 
@@ -1246,12 +1256,10 @@ test "injectPortFields overwrites existing port fields when requested" {
 
 test "writeFile creates file with correct content" {
     const allocator = std.testing.allocator;
-    const tmp_dir = "/tmp/test-orchestrator-write";
-    std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
-    try std_compat.fs.makeDirAbsolute(tmp_dir);
-    defer std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    const file_path = try std.fmt.allocPrint(allocator, "{s}/test.json", .{tmp_dir});
+    const file_path = try fixture.path(allocator, "test.json");
     defer allocator.free(file_path);
 
     try writeFile(file_path, "{\"hello\":\"world\"}");
@@ -1411,12 +1419,10 @@ test "extractCustomProviders neutralizes primary custom without dropping standar
 
 test "patchCustomProvidersIntoConfig restores custom fallback provider order" {
     const allocator = std.testing.allocator;
-    const tmp_dir = "/tmp/test-orchestrator-custom-fallback-patch";
-    std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
-    try std_compat.fs.makeDirAbsolute(tmp_dir);
-    defer std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    const config_path = try std.fs.path.join(allocator, &.{ tmp_dir, "config.json" });
+    const config_path = try fixture.path(allocator, "config.json");
     defer allocator.free(config_path);
     try writeFile(config_path,
         \\{"models":{"providers":{"openrouter":{"api_key":"sk-or"},"openai":{"api_key":""}}},"agents":{"defaults":{"model":{"primary":"openrouter/openrouter-auto"}}},"reliability":{"fallback_providers":["openai"]}}
@@ -1458,12 +1464,10 @@ test "patchCustomProvidersIntoConfig restores custom fallback provider order" {
 
 test "patchCustomProvidersIntoConfig restores primary custom and keeps standard fallback" {
     const allocator = std.testing.allocator;
-    const tmp_dir = "/tmp/test-orchestrator-primary-custom-patch";
-    std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
-    try std_compat.fs.makeDirAbsolute(tmp_dir);
-    defer std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    const config_path = try std.fs.path.join(allocator, &.{ tmp_dir, "config.json" });
+    const config_path = try fixture.path(allocator, "config.json");
     defer allocator.free(config_path);
     try writeFile(config_path,
         \\{"models":{"providers":{"openai":{"api_key":""},"openrouter":{"api_key":"sk-or"}}},"agents":{"defaults":{"model":{"primary":"openai/"}}},"reliability":{"fallback_providers":["openrouter"]}}

--- a/src/server.zig
+++ b/src/server.zig
@@ -30,6 +30,7 @@ const orchestrator = @import("installer/orchestrator.zig");
 const registry = @import("installer/registry.zig");
 const ui_assets = @import("ui_assets");
 const version = @import("version.zig");
+const test_helpers = @import("test_helpers.zig");
 
 const max_request_size: usize = 65_536;
 
@@ -1360,6 +1361,7 @@ fn serveStaticFile(allocator: std.mem.Allocator, target: []const u8) Response {
 // --- Test helpers ---
 
 const TestContext = struct {
+    fixture: test_helpers.TempPaths,
     state: *state_mod.State,
     paths: paths_mod.Paths,
     manager: manager_mod.Manager,
@@ -1367,19 +1369,18 @@ const TestContext = struct {
     server: Server,
 
     fn init(allocator: std.mem.Allocator) TestContext {
-        return initAtRoot(allocator, "/tmp/nullhub-test-server", "/tmp/nullhub-test-server-state.json");
-    }
-
-    fn initAtRoot(allocator: std.mem.Allocator, root: []const u8, state_path: []const u8) TestContext {
+        const fixture = test_helpers.TempPaths.init(allocator) catch @panic("TempPaths.init failed");
+        const state_path = fixture.paths.state(allocator) catch @panic("state path failed");
+        defer allocator.free(state_path);
         const state = allocator.create(state_mod.State) catch @panic("OOM");
         state.* = state_mod.State.init(allocator, state_path);
-        const paths = paths_mod.Paths.init(allocator, root) catch @panic("Paths.init failed");
         var ctx: TestContext = undefined;
+        ctx.fixture = fixture;
         ctx.state = state;
-        ctx.paths = paths;
-        ctx.manager = manager_mod.Manager.init(allocator, paths);
+        ctx.paths = fixture.paths;
+        ctx.manager = manager_mod.Manager.init(allocator, fixture.paths);
         ctx.mutex = .{};
-        ctx.server = Server.initWithState(allocator, state, paths, &ctx.manager, &ctx.mutex);
+        ctx.server = Server.initWithState(allocator, state, fixture.paths, &ctx.manager, &ctx.mutex);
         return ctx;
     }
 
@@ -1387,7 +1388,7 @@ const TestContext = struct {
         self.manager.deinit();
         self.state.deinit();
         allocator.destroy(self.state);
-        self.paths.deinit(allocator);
+        self.fixture.deinit();
     }
 
     fn route(self: *TestContext, allocator: std.mem.Allocator, method: []const u8, target: []const u8, body: []const u8) Response {
@@ -1412,18 +1413,11 @@ test "reconcileInstancesOnBoot adopts persisted managed instance without respawn
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-server-reconcile";
-    const tmp_state = "/tmp/nullhub-test-server-reconcile-state.json";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    std_compat.fs.deleteFileAbsolute(tmp_state) catch {};
-    defer std_compat.fs.deleteFileAbsolute(tmp_state) catch {};
-
-    var ctx = TestContext.initAtRoot(allocator, tmp_root, tmp_state);
+    var ctx = TestContext.init(allocator);
     defer ctx.deinit(allocator);
     try ctx.paths.ensureDirs();
 
-    const output_path = try std.fs.path.join(allocator, &.{ tmp_root, "starts.log" });
+    const output_path = try ctx.fixture.path(allocator, "starts.log");
     defer allocator.free(output_path);
 
     const binary_path = try ctx.paths.binary(allocator, "nullclaw", "1.0.0");
@@ -1487,18 +1481,11 @@ test "reconcileInstancesOnBoot restarts auto-start instance when persisted pid i
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-server-reconcile-stale";
-    const tmp_state = "/tmp/nullhub-test-server-reconcile-stale-state.json";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    std_compat.fs.deleteFileAbsolute(tmp_state) catch {};
-    defer std_compat.fs.deleteFileAbsolute(tmp_state) catch {};
-
-    var ctx = TestContext.initAtRoot(allocator, tmp_root, tmp_state);
+    var ctx = TestContext.init(allocator);
     defer ctx.deinit(allocator);
     try ctx.paths.ensureDirs();
 
-    const output_path = try std.fs.path.join(allocator, &.{ tmp_root, "starts.log" });
+    const output_path = try ctx.fixture.path(allocator, "starts.log");
     defer allocator.free(output_path);
 
     const binary_path = try ctx.paths.binary(allocator, "nullclaw", "1.0.0");

--- a/src/supervisor/manager.zig
+++ b/src/supervisor/manager.zig
@@ -818,10 +818,10 @@ pub const Manager = struct {
 
 test "Manager init and deinit (no leaks)" {
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-nullhub-mgr");
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 }
 
@@ -830,10 +830,10 @@ test "Manager deinit terminates tracked child processes" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-nullhub-mgr-deinit-kill");
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
 
     const spawned = try process.spawn(allocator, .{
         .binary = "/bin/sleep",
@@ -856,10 +856,10 @@ test "Manager deinit terminates tracked child processes" {
 
 test "getStatus returns null for unknown instance" {
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-nullhub-mgr");
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     try std.testing.expect(mgr.getStatus("foo", "bar") == null);
@@ -894,10 +894,10 @@ test "logSupervisor appends diagnostics to nullhub.log" {
 
 test "status reporting for manually-added instance" {
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-nullhub-mgr");
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const key = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ "mycomp", "myinst" });
@@ -990,10 +990,10 @@ test "restart preserves launch args with spaces" {
 
 test "getAllStatuses returns correct list" {
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-nullhub-mgr");
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     // Add two instances manually
@@ -1038,10 +1038,10 @@ test "getAllStatuses returns correct list" {
 
 test "tick: restarting with max_restarts exceeded transitions to failed" {
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-nullhub-mgr");
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const key = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ "comp", "inst" });
@@ -1062,10 +1062,10 @@ test "tick: restarting with max_restarts exceeded transitions to failed" {
 
 test "tick: restarting with restarts remaining transitions to failed (no binary)" {
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-nullhub-mgr");
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const key = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ "comp", "inst" });
@@ -1088,10 +1088,10 @@ test "tick: restarting with restarts remaining transitions to failed (no binary)
 
 test "tick: stopped and failed instances are not modified" {
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-nullhub-mgr");
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const key1 = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ "comp", "stopped-inst" });
@@ -1121,10 +1121,10 @@ test "tick: stopped and failed instances are not modified" {
 
 test "tick: starting instance without pid transitions to restarting" {
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-nullhub-mgr");
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     // An instance in .starting with a non-existent PID should go to .failed
@@ -1148,10 +1148,10 @@ test "tick: startup timeout transitions to restarting" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-nullhub-mgr-start-timeout");
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const spawned = try process.spawn(allocator, .{
@@ -1187,10 +1187,10 @@ test "tick: health failure threshold transitions to restarting" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-nullhub-mgr-health-restart");
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const spawned = try process.spawn(allocator, .{
@@ -1228,10 +1228,10 @@ test "tick: restarting with binary_path spawns new process" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-nullhub-mgr");
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const key = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ "comp", "restartable" });
@@ -1264,10 +1264,10 @@ test "tick: restarting with binary_path spawns new process" {
 
 test "tick: running instance with dead pid transitions to restarting" {
     const allocator = std.testing.allocator;
-    var p = try paths_mod.Paths.init(allocator, "/tmp/test-nullhub-mgr");
-    defer p.deinit(allocator);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const key = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ "comp", "crashed" });

--- a/src/supervisor/manager.zig
+++ b/src/supervisor/manager.zig
@@ -5,6 +5,7 @@ const health = @import("health.zig");
 const runtime_state = @import("runtime_state.zig");
 const paths_mod = @import("../core/paths.zig");
 const component_cli = @import("../core/component_cli.zig");
+const test_helpers = @import("../test_helpers.zig");
 
 pub const Status = enum {
     stopped,
@@ -866,20 +867,16 @@ test "getStatus returns null for unknown instance" {
 
 test "logSupervisor appends diagnostics to nullhub.log" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/test-nullhub-mgr-log-supervisor";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
-
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     mgr.logSupervisor("nullclaw", "diag", "first diagnostic {d}", .{@as(u8, 1)});
     mgr.logSupervisor("nullclaw", "diag", "second diagnostic", .{});
 
-    const logs_dir = try p.instanceLogs(allocator, "nullclaw", "diag");
+    const logs_dir = try fixture.paths.instanceLogs(allocator, "nullclaw", "diag");
     defer allocator.free(logs_dir);
     const log_path = try std.fs.path.join(allocator, &.{ logs_dir, "nullhub.log" });
     defer allocator.free(log_path);
@@ -935,14 +932,12 @@ test "restart preserves launch args with spaces" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
 
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/test-nullhub-mgr-restart-argv";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    try std_compat.fs.makeDirAbsolute(tmp_root);
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    const script_path = try std.fs.path.join(allocator, &.{ tmp_root, "capture-arg.sh" });
+    const script_path = try fixture.path(allocator, "capture-arg.sh");
     defer allocator.free(script_path);
-    const output_path = try std.fs.path.join(allocator, &.{ tmp_root, "captured.txt" });
+    const output_path = try fixture.path(allocator, "captured.txt");
     defer allocator.free(output_path);
 
     const script =
@@ -954,10 +949,7 @@ test "restart preserves launch args with spaces" {
     defer script_file.close();
     try script_file.writeAll(script);
 
-    var p = try paths_mod.Paths.init(allocator, tmp_root);
-    defer p.deinit(allocator);
-
-    var mgr = Manager.init(allocator, p);
+    var mgr = Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
     const launch_args = [_][]const u8{ script_path, "hello world", output_path };

--- a/src/supervisor/runtime_state.zig
+++ b/src/supervisor/runtime_state.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const std_compat = @import("compat");
 const fs_compat = @import("../fs_compat.zig");
 const paths_mod = @import("../core/paths.zig");
+const test_helpers = @import("../test_helpers.zig");
 
 pub const PersistedRuntimeView = struct {
     pid: u64,
@@ -127,14 +128,10 @@ pub fn delete(
 
 test "runtime state round-trips through instance.json" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-runtime-state";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var paths = try paths_mod.Paths.init(allocator, tmp_root);
-    defer paths.deinit(allocator);
-
-    try write(allocator, paths, "nullclaw", "demo", .{
+    try write(allocator, fixture.paths, "nullclaw", "demo", .{
         .pid = 42,
         .port = 8080,
         .health_endpoint = "/health",
@@ -147,7 +144,7 @@ test "runtime state round-trips through instance.json" {
         .starting_since = 1000,
     });
 
-    var loaded = (try load(allocator, paths, "nullclaw", "demo")).?;
+    var loaded = (try load(allocator, fixture.paths, "nullclaw", "demo")).?;
     defer loaded.deinit(allocator);
 
     try std.testing.expectEqual(@as(u64, 42), loaded.pid);
@@ -158,6 +155,6 @@ test "runtime state round-trips through instance.json" {
     try std.testing.expectEqual(@as(usize, 2), loaded.launch_args.len);
     try std.testing.expectEqualStrings("--verbose", loaded.launch_args[1]);
 
-    delete(allocator, paths, "nullclaw", "demo");
-    try std.testing.expect((try load(allocator, paths, "nullclaw", "demo")) == null);
+    delete(allocator, fixture.paths, "nullclaw", "demo");
+    try std.testing.expect((try load(allocator, fixture.paths, "nullclaw", "demo")) == null);
 }

--- a/src/test_helpers.zig
+++ b/src/test_helpers.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const std_compat = @import("compat");
+const paths_mod = @import("core/paths.zig");
+
+pub const TempPaths = struct {
+    allocator: std.mem.Allocator,
+    tmp: std.testing.TmpDir,
+    root: []u8,
+    paths: paths_mod.Paths,
+
+    pub fn init(allocator: std.mem.Allocator) !TempPaths {
+        const tmp = std.testing.tmpDir(.{});
+        const root = try std_compat.fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
+        errdefer allocator.free(root);
+
+        const paths = try paths_mod.Paths.init(allocator, root);
+        errdefer {
+            var owned_paths = paths;
+            owned_paths.deinit(allocator);
+        }
+
+        return .{
+            .allocator = allocator,
+            .tmp = tmp,
+            .root = root,
+            .paths = paths,
+        };
+    }
+
+    pub fn deinit(self: *TempPaths) void {
+        self.paths.deinit(self.allocator);
+        self.allocator.free(self.root);
+        self.tmp.cleanup();
+        self.* = undefined;
+    }
+
+    pub fn path(self: TempPaths, allocator: std.mem.Allocator, sub_path: []const u8) ![]const u8 {
+        return std.fs.path.join(allocator, &.{ self.root, sub_path });
+    }
+};
+
+test "TempPaths creates isolated nullhub root" {
+    const allocator = std.testing.allocator;
+
+    var fixture = try TempPaths.init(allocator);
+    defer fixture.deinit();
+
+    try std.testing.expect(std.fs.path.isAbsolute(fixture.root));
+    try std.testing.expectEqualStrings(fixture.root, fixture.paths.root);
+
+    try fixture.paths.ensureDirs();
+
+    const state_path = try fixture.path(allocator, "state.json");
+    defer allocator.free(state_path);
+    try std.testing.expect(std.mem.startsWith(u8, state_path, fixture.root));
+}

--- a/src/test_helpers.zig
+++ b/src/test_helpers.zig
@@ -10,6 +10,8 @@ pub const TempPaths = struct {
 
     pub fn init(allocator: std.mem.Allocator) !TempPaths {
         const tmp = std.testing.tmpDir(.{});
+        errdefer tmp.cleanup();
+
         const root = try std_compat.fs.Dir.wrap(tmp.dir).realpathAlloc(allocator, ".");
         errdefer allocator.free(root);
 


### PR DESCRIPTION
## Summary

- add a small shared `src/test_helpers.zig` fixture with `TempPaths`, which creates an isolated temporary NullHub root backed by `std.testing.tmpDir`
- use the new fixture in existing backend tests that previously relied on hardcoded `/tmp/...` paths and manual cleanup
- adopt the fixture in real tests across three subsystems: supervisor runtime-state persistence, supervisor manager log/restart behavior, and installer directory creation
- keep the helper intentionally narrow so it unlocks later testing work without introducing a broad test framework

## Validation

- `zig build test -Dembed-ui=false -Dbuild-ui=false --summary all`
- `npm --prefix ui ci --no-audit --no-fund`
- `npm --prefix ui run build`
- `bash tests/test_e2e.sh`
- `zig fmt --check src/`
- `git diff --check`

## Notes

- this PR focuses only on temporary NullHub root/path isolation; it does not yet add fake upstream HTTP helpers or broader integration harnesses
- the immediate benefit is removal of several hardcoded `/tmp` test roots and more reliable cleanup semantics for future TDD-style backend tests
- a natural follow-up is extending the fixture layer with a tiny fake upstream helper for orchestration and installer/update integration tests