### PR TITLE
fix(auth): protect bare api root path

### DIFF
--- a/src/auth.zig
+++ b/src/auth.zig
@@ -30,6 +30,7 @@ pub fn extractBearerToken(raw_request: []const u8) ?[]const u8 {
 /// Public paths: GET /health and any path not starting with /api/.
 pub fn isPublicPath(path: []const u8) bool {
     if (std.mem.eql(u8, path, "/health")) return true;
+    if (std.mem.eql(u8, path, "/api")) return false;
     if (!std.mem.startsWith(u8, path, "/api/")) return true;
     return false;
 }
@@ -78,4 +79,8 @@ test "isPublicPath returns true for static paths like /index.html" {
 
 test "isPublicPath returns false for /api/status" {
     try std.testing.expect(isPublicPath("/api/status") == false);
+}
+
+test "isPublicPath returns false for bare /api" {
+    try std.testing.expect(isPublicPath("/api") == false);
 }

--- a/src/auth.zig
+++ b/src/auth.zig
@@ -26,13 +26,22 @@ pub fn extractBearerToken(raw_request: []const u8) ?[]const u8 {
     return null;
 }
 
+fn pathWithoutQuery(path: []const u8) []const u8 {
+    const query = std.mem.indexOfScalar(u8, path, '?') orelse return path;
+    return path[0..query];
+}
+
+pub fn isApiPath(path: []const u8) bool {
+    const clean_path = pathWithoutQuery(path);
+    return std.mem.eql(u8, clean_path, "/api") or
+        std.mem.startsWith(u8, clean_path, "/api/");
+}
+
 /// Returns true for paths that do not require authentication.
-/// Public paths: GET /health and any path not starting with /api/.
+/// Public paths: /health and any path outside the /api namespace.
 pub fn isPublicPath(path: []const u8) bool {
-    if (std.mem.eql(u8, path, "/health")) return true;
-    if (std.mem.eql(u8, path, "/api")) return false;
-    if (!std.mem.startsWith(u8, path, "/api/")) return true;
-    return false;
+    if (std.mem.eql(u8, pathWithoutQuery(path), "/health")) return true;
+    return !isApiPath(path);
 }
 
 // --- Tests ---
@@ -83,4 +92,17 @@ test "isPublicPath returns false for /api/status" {
 
 test "isPublicPath returns false for bare /api" {
     try std.testing.expect(isPublicPath("/api") == false);
+}
+
+test "isPublicPath returns false for bare /api with query string" {
+    try std.testing.expect(isPublicPath("/api?format=json") == false);
+}
+
+test "isApiPath only matches the api namespace" {
+    try std.testing.expect(isApiPath("/api"));
+    try std.testing.expect(isApiPath("/api?format=json"));
+    try std.testing.expect(isApiPath("/api/status"));
+    try std.testing.expect(isApiPath("/api/status?format=json"));
+    try std.testing.expect(!isApiPath("/apiary"));
+    try std.testing.expect(!isApiPath("/ui/api"));
 }

--- a/src/server.zig
+++ b/src/server.zig
@@ -1125,7 +1125,7 @@ pub const Server = struct {
         }
 
         // Serve UI module files from data directory (~/.nullhub/ui/{name}@{version}/...)
-        if (!std.mem.startsWith(u8, target, "/api/") and std.mem.startsWith(u8, target, "/ui/")) {
+        if (!auth.isApiPath(target) and std.mem.startsWith(u8, target, "/ui/")) {
             // Check if this looks like a module path: /ui/{name}@{version}/...
             if (target.len > 4) {
                 const after_ui = target[4..]; // after "/ui/"
@@ -1136,7 +1136,7 @@ pub const Server = struct {
         }
 
         // For non-API paths, attempt to serve static files from the embedded UI bundle.
-        if (!std.mem.startsWith(u8, target, "/api/")) {
+        if (!auth.isApiPath(target)) {
             return serveStaticFile(allocator, target);
         }
 
@@ -1242,7 +1242,7 @@ pub fn extractHeader(raw: []const u8, name: []const u8) ?[]const u8 {
 }
 
 fn requestOriginAllowed(raw_request: []const u8, target: []const u8, bind_host: []const u8, port: u16, extra_origins: []const []const u8) bool {
-    if (!std.mem.startsWith(u8, target, "/api/")) return true;
+    if (!auth.isApiPath(target)) return true;
     const origin = extractHeader(raw_request, "Origin") orelse return true;
     return isAllowedCorsOrigin(origin, bind_host, port, extra_origins);
 }
@@ -1684,6 +1684,26 @@ test "route unknown API path returns JSON 404" {
     try std.testing.expectEqualStrings("{\"error\":\"not found\"}", resp.body);
 }
 
+test "route bare API root returns JSON 404 instead of static fallback" {
+    var ctx = TestContext.init(std.testing.allocator);
+    defer ctx.deinit(std.testing.allocator);
+
+    const resp = ctx.route(std.testing.allocator, "GET", "/api", "");
+    try std.testing.expectEqualStrings("404 Not Found", resp.status);
+    try std.testing.expectEqualStrings("application/json", resp.content_type);
+    try std.testing.expectEqualStrings("{\"error\":\"not found\"}", resp.body);
+}
+
+test "route bare API root with query returns JSON 404 instead of static fallback" {
+    var ctx = TestContext.init(std.testing.allocator);
+    defer ctx.deinit(std.testing.allocator);
+
+    const resp = ctx.route(std.testing.allocator, "GET", "/api?format=json", "");
+    try std.testing.expectEqualStrings("404 Not Found", resp.status);
+    try std.testing.expectEqualStrings("application/json", resp.content_type);
+    try std.testing.expectEqualStrings("{\"error\":\"not found\"}", resp.body);
+}
+
 test "route GET /api/components returns component list" {
     var ctx = TestContext.init(std.testing.allocator);
     defer ctx.deinit(std.testing.allocator);
@@ -1791,6 +1811,14 @@ test "requestOriginAllowed rejects foreign API origins" {
         "Host: 127.0.0.1:19800\r\n" ++
         "Origin: http://nullhub.localhost:19800\r\n\r\n";
     try std.testing.expect(requestOriginAllowed(local_raw, "/api/status", "127.0.0.1", 19800, &.{}));
+}
+
+test "requestOriginAllowed treats bare API root with query as API" {
+    const evil_raw =
+        "GET /api?format=json HTTP/1.1\r\n" ++
+        "Host: 127.0.0.1:19800\r\n" ++
+        "Origin: http://evil.example:19800\r\n\r\n";
+    try std.testing.expect(!requestOriginAllowed(evil_raw, "/api?format=json", "127.0.0.1", 19800, &.{}));
 }
 
 test "requestOriginAllowed honors configured extra origins" {


### PR DESCRIPTION
## Summary

- fix `auth.isPublicPath()` so bare `/api` is treated as a protected path instead of falling through as public
- add a regression test for `/api` alongside the existing `/api/status` protected-path coverage
- close a small but real auth boundary gap in the server auth gate, which checks `isPublicPath(target)` before requiring a bearer token
- keep the change narrowly scoped to auth-path classification

## Validation

- `zig build test -Dembed-ui=false -Dbuild-ui=false --summary all`
- `npm --prefix ui ci --no-audit --no-fund`
- `npm --prefix ui run build`
- `bash tests/test_e2e.sh`
- `zig fmt --check src/`
- `git diff --check`

## Notes

- this is a production fix plus regression test, not just a test-only change
- the behavior is consistent with the existing intent that API paths require auth unless explicitly public (`/health`)
- follow-up Phase 5 slices will continue with orchestration proxy coverage, installer failure/cleanup coverage, and service helper boundary coverage