### PR TITLE
test(service): tighten systemctl status parsing

### DIFF
--- a/src/service.zig
+++ b/src/service.zig
@@ -361,7 +361,7 @@ fn runCaptureStatus(allocator: std.mem.Allocator, argv: []const []const u8) !Cap
             return .{
                 .success = false,
                 .stdout = try allocator.dupe(u8, ""),
-                .stderr = try allocator.dupe(u8, "command not found"),
+                .stderr = try std.fmt.allocPrint(allocator, "{s}: command not found", .{argv[0]}),
             };
         },
         else => return err,
@@ -383,7 +383,7 @@ fn captureStatusDetail(status: *const CaptureStatus) []const u8 {
 }
 
 fn isSystemctlMissingDetail(detail: []const u8) bool {
-    return std.ascii.indexOfIgnoreCase(detail, "command not found") != null or
+    return std.ascii.indexOfIgnoreCase(detail, "systemctl: command not found") != null or
         std.ascii.indexOfIgnoreCase(detail, "systemctl: not found") != null or
         std.ascii.indexOfIgnoreCase(detail, "systemctl not found") != null or
         std.ascii.indexOfIgnoreCase(detail, "systemctl: no such file or directory") != null;
@@ -414,13 +414,26 @@ test "preferredHomebrewShimPath ignores non-Cellar paths" {
 test "isSystemctlMissingDetail matches missing command output" {
     try std.testing.expect(isSystemctlMissingDetail("systemctl: command not found"));
     try std.testing.expect(isSystemctlMissingDetail("systemctl: not found"));
+    try std.testing.expect(isSystemctlMissingDetail("systemctl not found"));
+    try std.testing.expect(isSystemctlMissingDetail("systemctl: no such file or directory"));
 }
 
-test "isSystemctlMissingDetail ignores missing unit output" {
+test "isSystemctlMissingDetail ignores unrelated missing output" {
+    try std.testing.expect(!isSystemctlMissingDetail("command not found"));
     try std.testing.expect(!isSystemctlMissingDetail("Unit nullhub.service could not be found."));
 }
 
 test "isSystemdUnavailableDetail matches user bus errors" {
     try std.testing.expect(isSystemdUnavailableDetail("Failed to connect to bus: No medium found"));
     try std.testing.expect(isSystemdUnavailableDetail("System has not been booted with systemd as init system (PID 1). Can't operate."));
+}
+
+test "runCaptureStatus includes executable name for missing commands" {
+    const status = try runCaptureStatus(std.testing.allocator, &.{"nullhub-command-that-should-not-exist"});
+    defer std.testing.allocator.free(status.stdout);
+    defer std.testing.allocator.free(status.stderr);
+
+    try std.testing.expect(!status.success);
+    try std.testing.expectEqualStrings("", status.stdout);
+    try std.testing.expectEqualStrings("nullhub-command-that-should-not-exist: command not found", status.stderr);
 }

--- a/src/service.zig
+++ b/src/service.zig
@@ -384,7 +384,9 @@ fn captureStatusDetail(status: *const CaptureStatus) []const u8 {
 
 fn isSystemctlMissingDetail(detail: []const u8) bool {
     return std.ascii.indexOfIgnoreCase(detail, "command not found") != null or
-        std.ascii.indexOfIgnoreCase(detail, "not found") != null;
+        std.ascii.indexOfIgnoreCase(detail, "systemctl: not found") != null or
+        std.ascii.indexOfIgnoreCase(detail, "systemctl not found") != null or
+        std.ascii.indexOfIgnoreCase(detail, "systemctl: no such file or directory") != null;
 }
 
 fn isSystemdUnavailableDetail(detail: []const u8) bool {
@@ -407,4 +409,18 @@ test "preferredHomebrewShimPath resolves Linux Homebrew Cellar install" {
 
 test "preferredHomebrewShimPath ignores non-Cellar paths" {
     try std.testing.expect((try preferredHomebrewShimPath(std.testing.allocator, "/usr/local/bin/nullhub")) == null);
+}
+
+test "isSystemctlMissingDetail matches missing command output" {
+    try std.testing.expect(isSystemctlMissingDetail("systemctl: command not found"));
+    try std.testing.expect(isSystemctlMissingDetail("systemctl: not found"));
+}
+
+test "isSystemctlMissingDetail ignores missing unit output" {
+    try std.testing.expect(!isSystemctlMissingDetail("Unit nullhub.service could not be found."));
+}
+
+test "isSystemdUnavailableDetail matches user bus errors" {
+    try std.testing.expect(isSystemdUnavailableDetail("Failed to connect to bus: No medium found"));
+    try std.testing.expect(isSystemdUnavailableDetail("System has not been booted with systemd as init system (PID 1). Can't operate."));
 }


### PR DESCRIPTION
## Summary

- tighten systemctl availability detection so generic "not found" text does not misclassify missing service units as a missing `systemctl` binary
- add focused regression coverage for missing-command detection and systemd user-session detection helpers
- keep the change isolated to service status parsing so API behavior remains stable while error classification becomes more accurate

## Validation

- `zig build test -Dembed-ui=false -Dbuild-ui=false --summary all`
- `npm --prefix ui ci --no-audit --no-fund`
- `npm --prefix ui run build`
- `bash tests/test_e2e.sh`
- `zig fmt --check src/`
- `git diff --check`

## Notes

- this is intentionally a boundary-only slice: it protects the helper logic that decides whether to report "systemctl unavailable" versus a normal command failure
- a typical missing-unit response like `Unit nullhub.service could not be found.` should no longer be treated as if the `systemctl` executable itself is absent