### PR TITLE
test(integration): add structured HTTP smoke harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           {"os":"macos-latest","target":"macos-aarch64","zig_target":"aarch64-macos"},
           {"os":"windows-latest","target":"windows-x86_64","zig_target":"x86_64-windows"}
         ]
-      test_command: zig build test -Dembed-ui=false -Dbuild-ui=false --summary all
+      test_command: bash tests/test_backend.sh
       pre_build_command: |
         npm --prefix ui ci --no-audit --no-fund
         npm --prefix ui run build

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Backend:
 
 ```bash
 zig build test -Dembed-ui=false -Dbuild-ui=false --summary all
+zig build test-integration -Dembed-ui=false -Dbuild-ui=false --summary all
 ```
 
 Frontend:
@@ -140,6 +141,9 @@ End-to-end:
 ```bash
 ./tests/test_e2e.sh
 ```
+
+`zig build test-integration` runs structured backend HTTP integration tests
+against a real `nullhub` process started in a temporary home directory.
 
 ## Tech Stack
 

--- a/build.zig
+++ b/build.zig
@@ -108,7 +108,8 @@ pub fn build(b: *std.Build) void {
     const run_integration_tests = b.addRunArtifact(integration_tests);
     run_integration_tests.step.dependOn(b.getInstallStep());
     run_integration_tests.setCwd(b.path("."));
-    run_integration_tests.setEnvironmentVariable("NULLHUB_INTEGRATION_BIN", "zig-out/bin/nullhub");
+    const integration_bin_name = b.fmt("nullhub{s}", .{target.result.exeFileExt()});
+    run_integration_tests.setEnvironmentVariable("NULLHUB_INTEGRATION_BIN", b.getInstallPath(.bin, integration_bin_name));
     const integration_test_step = b.step("test-integration", "Run integration tests");
     integration_test_step.dependOn(&run_integration_tests.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -91,6 +91,26 @@ pub fn build(b: *std.Build) void {
     const run_tests = b.addRunArtifact(exe_unit_tests);
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_tests.step);
+
+    const integration_test_module = b.createModule(.{
+        .root_source_file = b.path("src/integration_tests.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    integration_test_module.addImport("build_options", build_options_module);
+    integration_test_module.addImport("ui_assets", ui_assets_module);
+    integration_test_module.addImport("compat", compat_module);
+
+    const integration_tests = b.addTest(.{
+        .root_module = integration_test_module,
+    });
+    const run_integration_tests = b.addRunArtifact(integration_tests);
+    run_integration_tests.step.dependOn(b.getInstallStep());
+    run_integration_tests.setCwd(b.path("."));
+    run_integration_tests.setEnvironmentVariable("NULLHUB_INTEGRATION_BIN", "zig-out/bin/nullhub");
+    const integration_test_step = b.step("test-integration", "Run integration tests");
+    integration_test_step.dependOn(&run_integration_tests.step);
 }
 
 fn createUiAssetsModule(b: *std.Build, embed_ui: bool) *std.Build.Module {

--- a/src/compat/net.zig
+++ b/src/compat/net.zig
@@ -91,10 +91,10 @@ pub const Stream = struct {
                 }
             }
         }
-        var stream_reader = self.toInner().reader(shared.io(), &[_]u8{});
-        return stream_reader.interface.readSliceShort(buffer) catch |err| switch (err) {
-            error.ReadFailed => return stream_reader.err orelse error.Unexpected,
-        };
+        if (buffer.len == 0) return 0;
+        const io = shared.io();
+        var data: [1][]u8 = .{buffer};
+        return io.vtable.netRead(io.userdata, self.handle, &data);
     }
 
     pub fn write(self: Stream, bytes: []const u8) WriteError!usize {

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 const std_compat = @import("compat");
 const builtin = @import("builtin");
-const paths_mod = @import("core/paths.zig");
-const state_mod = @import("core/state.zig");
 
 const IntegrationServer = struct {
     allocator: std.mem.Allocator,
@@ -10,8 +8,8 @@ const IntegrationServer = struct {
     temp_root: []const u8,
     home_dir: []const u8,
     port: u16,
-    child: std_compat.process.Child,
-    env_map: std_compat.process.EnvMap,
+    child: ?std_compat.process.Child = null,
+    env_map: ?std_compat.process.EnvMap = null,
 
     fn start(allocator: std.mem.Allocator) !IntegrationServer {
         if (builtin.os.tag == .wasi) return error.SkipZigTest;
@@ -21,37 +19,23 @@ const IntegrationServer = struct {
         }.call);
     }
 
-    fn startWithEnv(
-        allocator: std.mem.Allocator,
-        extra_env: []const EnvEntry,
-    ) !IntegrationServer {
-        return startWithSeedAndEnv(allocator, struct {
-            fn call(_: *IntegrationServer) !void {}
-        }.call, extra_env);
-    }
-
     fn startWithSeed(
         allocator: std.mem.Allocator,
         comptime seedFn: *const fn (*IntegrationServer) anyerror!void,
     ) !IntegrationServer {
-        return startWithSeedAndEnv(allocator, seedFn, &.{});
-    }
-
-    fn startWithSeedAndEnv(
-        allocator: std.mem.Allocator,
-        comptime seedFn: *const fn (*IntegrationServer) anyerror!void,
-        extra_env: []const EnvEntry,
-    ) !IntegrationServer {
         if (builtin.os.tag == .wasi) return error.SkipZigTest;
 
         var tmp_dir = std.testing.tmpDir(.{});
-        errdefer tmp_dir.cleanup();
+        var cleanup_tmp_dir = true;
+        errdefer if (cleanup_tmp_dir) tmp_dir.cleanup();
 
         const temp_root = try std_compat.fs.Dir.wrap(tmp_dir.dir).realpathAlloc(allocator, ".");
-        errdefer allocator.free(temp_root);
+        var cleanup_temp_root = true;
+        errdefer if (cleanup_temp_root) allocator.free(temp_root);
 
         const home_dir = try std.fs.path.join(allocator, &.{ temp_root, "home" });
-        errdefer allocator.free(home_dir);
+        var cleanup_home_dir = true;
+        errdefer if (cleanup_home_dir) allocator.free(home_dir);
         try std_compat.fs.makeDirAbsolute(home_dir);
 
         var server = IntegrationServer{
@@ -60,9 +44,10 @@ const IntegrationServer = struct {
             .temp_root = temp_root,
             .home_dir = home_dir,
             .port = undefined,
-            .child = undefined,
-            .env_map = undefined,
         };
+        cleanup_tmp_dir = false;
+        cleanup_temp_root = false;
+        cleanup_home_dir = false;
         errdefer server.deinit();
 
         try seedFn(&server);
@@ -76,31 +61,31 @@ const IntegrationServer = struct {
         defer allocator.free(exe_path);
 
         server.env_map = try std_compat.process.getEnvMap(allocator);
-        errdefer server.env_map.deinit();
-        try server.env_map.put("HOME", home_dir);
-        for (extra_env) |entry| try server.env_map.put(entry.key, entry.value);
+        try server.env_map.?.put("HOME", home_dir);
 
         const argv = try allocator.dupe([]const u8, &.{ exe_path, "serve", "--port", port_text, "--no-open" });
         defer allocator.free(argv);
 
-        server.child = std_compat.process.Child.init(argv, allocator);
-        server.child.cwd = ".";
-        server.child.env_map = &server.env_map;
-        server.child.stdin_behavior = .Ignore;
-        server.child.stdout_behavior = .Ignore;
-        server.child.stderr_behavior = .Ignore;
-        try server.child.spawn();
+        var child = std_compat.process.Child.init(argv, allocator);
+        child.cwd = ".";
+        child.env_map = &server.env_map.?;
+        child.stdin_behavior = .Ignore;
+        child.stdout_behavior = .Ignore;
+        child.stderr_behavior = if (builtin.os.tag == .windows) .Inherit else .Ignore;
+        try child.spawn();
+        child.argv = &.{};
+        server.child = child;
 
         try server.waitUntilReady();
         return server;
     }
 
     fn deinit(self: *IntegrationServer) void {
-        if (@intFromPtr(self.child.argv.ptr) != 0) {
-            _ = self.child.kill() catch {};
-            _ = self.child.wait() catch {};
+        if (self.child) |*child| {
+            _ = child.kill() catch {};
+            _ = child.wait() catch {};
         }
-        if (self.env_map.count() > 0) self.env_map.deinit();
+        if (self.env_map) |*env_map| env_map.deinit();
         self.allocator.free(self.home_dir);
         self.allocator.free(self.temp_root);
         self.tmp_dir.cleanup();
@@ -109,7 +94,8 @@ const IntegrationServer = struct {
 
     fn waitUntilReady(self: *IntegrationServer) !void {
         var attempt: usize = 0;
-        while (attempt < 40) : (attempt += 1) {
+        const max_attempts = 40;
+        while (attempt < max_attempts) : (attempt += 1) {
             const result = self.fetch(.{ .path = "/health" });
             if (result) |resp| {
                 defer resp.deinit(self.allocator);
@@ -126,24 +112,32 @@ const IntegrationServer = struct {
         const url = try std.fmt.allocPrint(self.allocator, "http://127.0.0.1:{d}{s}", .{ self.port, req.path });
         defer self.allocator.free(url);
 
-        var client: std.http.Client = .{ .allocator = self.allocator, .io = std_compat.io() };
+        const payload = payloadForRequest(req.method, req.body);
+        var headers: std.http.Client.Request.Headers = .{
+            .connection = .{ .override = "close" },
+        };
+        if (payload) |bytes| {
+            if (bytes.len > 0) {
+                headers.content_type = .{ .override = "application/json" };
+            }
+        }
+
+        var client: std.http.Client = .{
+            .allocator = self.allocator,
+            .io = std_compat.io(),
+        };
         defer client.deinit();
 
         var body: std.Io.Writer.Allocating = .init(self.allocator);
         errdefer body.deinit();
 
-        var header_buf: [1]std.http.Header = undefined;
-        const extra_headers: []const std.http.Header = if (req.body.len > 0) blk: {
-            header_buf[0] = .{ .name = "Content-Type", .value = "application/json" };
-            break :blk header_buf[0..1];
-        } else &.{};
-
         const result = try client.fetch(.{
             .location = .{ .url = url },
             .method = req.method,
-            .payload = if (req.body.len > 0 or req.method.requestHasBody()) req.body else null,
+            .payload = payload,
+            .keep_alive = false,
+            .headers = headers,
             .response_writer = &body.writer,
-            .extra_headers = extra_headers,
         });
 
         return .{
@@ -152,17 +146,16 @@ const IntegrationServer = struct {
         };
     }
 
-    fn paths(self: *IntegrationServer) !paths_mod.Paths {
-        const root = try std.fs.path.join(self.allocator, &.{ self.home_dir, ".nullhub" });
-        defer self.allocator.free(root);
-        return try paths_mod.Paths.init(self.allocator, root);
+    fn nullhubRoot(self: *IntegrationServer) ![]const u8 {
+        return std.fs.path.join(self.allocator, &.{ self.home_dir, ".nullhub" });
     }
 };
 
-const EnvEntry = struct {
-    key: []const u8,
-    value: []const u8,
-};
+fn payloadForRequest(method: std.http.Method, body: []const u8) ?[]const u8 {
+    if (body.len > 0) return body;
+    if (method.requestHasBody()) return body;
+    return null;
+}
 
 const Request = struct {
     path: []const u8,
@@ -186,23 +179,44 @@ fn reservePort() !u16 {
     return listener.listen_address.in.getPort();
 }
 
+const StateInstanceEntry = struct {
+    version: []const u8,
+    auto_start: bool = false,
+    launch_mode: []const u8 = "gateway",
+    verbose: bool = false,
+};
+
 fn seedManagedInstance(server: *IntegrationServer, component: []const u8, name: []const u8) !void {
-    var paths = try server.paths();
-    defer paths.deinit(server.allocator);
-    try paths.ensureDirs();
+    const root = try server.nullhubRoot();
+    defer server.allocator.free(root);
+    try std_compat.fs.cwd().makePath(root);
 
-    const state_path = try paths.state(server.allocator);
+    const state_path = try std.fs.path.join(server.allocator, &.{ root, "state.json" });
     defer server.allocator.free(state_path);
-    var state = state_mod.State.init(server.allocator, state_path);
-    defer state.deinit();
 
-    try state.addInstance(component, name, .{
+    var component_instances = std.json.ArrayHashMap(StateInstanceEntry){};
+    defer component_instances.deinit(server.allocator);
+    try component_instances.map.put(server.allocator, name, .{
         .version = "1.0.0",
         .auto_start = false,
         .launch_mode = "gateway",
         .verbose = false,
     });
-    try state.save();
+
+    var instances = std.json.ArrayHashMap(std.json.ArrayHashMap(StateInstanceEntry)){};
+    defer instances.deinit(server.allocator);
+    try instances.map.put(server.allocator, component, component_instances);
+
+    const state_json = try std.json.Stringify.valueAlloc(server.allocator, .{
+        .instances = instances,
+        .saved_providers = &.{},
+        .saved_channels = &.{},
+    }, .{ .whitespace = .indent_2 });
+    defer server.allocator.free(state_json);
+
+    const file = try std_compat.fs.createFileAbsolute(state_path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(state_json);
 }
 
 test "integration harness serves health and core api routes" {

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const std_compat = @import("compat");
 const builtin = @import("builtin");
+const paths_mod = @import("core/paths.zig");
+const state_mod = @import("core/state.zig");
 
 const IntegrationServer = struct {
     allocator: std.mem.Allocator,
@@ -14,6 +16,34 @@ const IntegrationServer = struct {
     fn start(allocator: std.mem.Allocator) !IntegrationServer {
         if (builtin.os.tag == .wasi) return error.SkipZigTest;
 
+        return startWithSeed(allocator, struct {
+            fn call(_: *IntegrationServer) !void {}
+        }.call);
+    }
+
+    fn startWithEnv(
+        allocator: std.mem.Allocator,
+        extra_env: []const EnvEntry,
+    ) !IntegrationServer {
+        return startWithSeedAndEnv(allocator, struct {
+            fn call(_: *IntegrationServer) !void {}
+        }.call, extra_env);
+    }
+
+    fn startWithSeed(
+        allocator: std.mem.Allocator,
+        comptime seedFn: *const fn (*IntegrationServer) anyerror!void,
+    ) !IntegrationServer {
+        return startWithSeedAndEnv(allocator, seedFn, &.{});
+    }
+
+    fn startWithSeedAndEnv(
+        allocator: std.mem.Allocator,
+        comptime seedFn: *const fn (*IntegrationServer) anyerror!void,
+        extra_env: []const EnvEntry,
+    ) !IntegrationServer {
+        if (builtin.os.tag == .wasi) return error.SkipZigTest;
+
         var tmp_dir = std.testing.tmpDir(.{});
         errdefer tmp_dir.cleanup();
 
@@ -24,51 +54,53 @@ const IntegrationServer = struct {
         errdefer allocator.free(home_dir);
         try std_compat.fs.makeDirAbsolute(home_dir);
 
+        var server = IntegrationServer{
+            .allocator = allocator,
+            .tmp_dir = tmp_dir,
+            .temp_root = temp_root,
+            .home_dir = home_dir,
+            .port = undefined,
+            .child = undefined,
+            .env_map = undefined,
+        };
+        errdefer server.deinit();
+
+        try seedFn(&server);
+
         const port = try reservePort();
+        server.port = port;
         const port_text = try std.fmt.allocPrint(allocator, "{d}", .{port});
         defer allocator.free(port_text);
 
         const exe_path = try std_compat.process.getEnvVarOwned(allocator, "NULLHUB_INTEGRATION_BIN");
         defer allocator.free(exe_path);
 
-        var env_map = try std_compat.process.getEnvMap(allocator);
-        errdefer env_map.deinit();
-        try env_map.put("HOME", home_dir);
+        server.env_map = try std_compat.process.getEnvMap(allocator);
+        errdefer server.env_map.deinit();
+        try server.env_map.put("HOME", home_dir);
+        for (extra_env) |entry| try server.env_map.put(entry.key, entry.value);
 
         const argv = try allocator.dupe([]const u8, &.{ exe_path, "serve", "--port", port_text, "--no-open" });
         defer allocator.free(argv);
 
-        var child = std_compat.process.Child.init(argv, allocator);
-        child.cwd = ".";
-        child.env_map = &env_map;
-        child.stdin_behavior = .Ignore;
-        child.stdout_behavior = .Ignore;
-        child.stderr_behavior = .Ignore;
-        try child.spawn();
-        errdefer {
-            _ = child.kill() catch {};
-            _ = child.wait() catch {};
-        }
-
-        var server = IntegrationServer{
-            .allocator = allocator,
-            .tmp_dir = tmp_dir,
-            .temp_root = temp_root,
-            .home_dir = home_dir,
-            .port = port,
-            .child = child,
-            .env_map = env_map,
-        };
-        errdefer server.deinit();
+        server.child = std_compat.process.Child.init(argv, allocator);
+        server.child.cwd = ".";
+        server.child.env_map = &server.env_map;
+        server.child.stdin_behavior = .Ignore;
+        server.child.stdout_behavior = .Ignore;
+        server.child.stderr_behavior = .Ignore;
+        try server.child.spawn();
 
         try server.waitUntilReady();
         return server;
     }
 
     fn deinit(self: *IntegrationServer) void {
-        _ = self.child.kill() catch {};
-        _ = self.child.wait() catch {};
-        self.env_map.deinit();
+        if (@intFromPtr(self.child.argv.ptr) != 0) {
+            _ = self.child.kill() catch {};
+            _ = self.child.wait() catch {};
+        }
+        if (self.env_map.count() > 0) self.env_map.deinit();
         self.allocator.free(self.home_dir);
         self.allocator.free(self.temp_root);
         self.tmp_dir.cleanup();
@@ -78,7 +110,7 @@ const IntegrationServer = struct {
     fn waitUntilReady(self: *IntegrationServer) !void {
         var attempt: usize = 0;
         while (attempt < 40) : (attempt += 1) {
-            const result = self.fetch("/health");
+            const result = self.fetch(.{ .path = "/health" });
             if (result) |resp| {
                 defer resp.deinit(self.allocator);
                 if (resp.status == .ok) return;
@@ -90,8 +122,8 @@ const IntegrationServer = struct {
         return error.ServerNotReady;
     }
 
-    fn fetch(self: *IntegrationServer, path: []const u8) !HttpResponse {
-        const url = try std.fmt.allocPrint(self.allocator, "http://127.0.0.1:{d}{s}", .{ self.port, path });
+    fn fetch(self: *IntegrationServer, req: Request) !HttpResponse {
+        const url = try std.fmt.allocPrint(self.allocator, "http://127.0.0.1:{d}{s}", .{ self.port, req.path });
         defer self.allocator.free(url);
 
         var client: std.http.Client = .{ .allocator = self.allocator, .io = std_compat.io() };
@@ -100,10 +132,18 @@ const IntegrationServer = struct {
         var body: std.Io.Writer.Allocating = .init(self.allocator);
         errdefer body.deinit();
 
+        var header_buf: [1]std.http.Header = undefined;
+        const extra_headers: []const std.http.Header = if (req.body.len > 0) blk: {
+            header_buf[0] = .{ .name = "Content-Type", .value = "application/json" };
+            break :blk header_buf[0..1];
+        } else &.{};
+
         const result = try client.fetch(.{
             .location = .{ .url = url },
-            .method = .GET,
+            .method = req.method,
+            .payload = if (req.body.len > 0 or req.method.requestHasBody()) req.body else null,
             .response_writer = &body.writer,
+            .extra_headers = extra_headers,
         });
 
         return .{
@@ -111,6 +151,23 @@ const IntegrationServer = struct {
             .body = try body.toOwnedSlice(),
         };
     }
+
+    fn paths(self: *IntegrationServer) !paths_mod.Paths {
+        const root = try std.fs.path.join(self.allocator, &.{ self.home_dir, ".nullhub" });
+        defer self.allocator.free(root);
+        return try paths_mod.Paths.init(self.allocator, root);
+    }
+};
+
+const EnvEntry = struct {
+    key: []const u8,
+    value: []const u8,
+};
+
+const Request = struct {
+    path: []const u8,
+    method: std.http.Method = .GET,
+    body: []const u8 = "",
 };
 
 const HttpResponse = struct {
@@ -129,18 +186,37 @@ fn reservePort() !u16 {
     return listener.listen_address.in.getPort();
 }
 
+fn seedManagedInstance(server: *IntegrationServer, component: []const u8, name: []const u8) !void {
+    var paths = try server.paths();
+    defer paths.deinit(server.allocator);
+    try paths.ensureDirs();
+
+    const state_path = try paths.state(server.allocator);
+    defer server.allocator.free(state_path);
+    var state = state_mod.State.init(server.allocator, state_path);
+    defer state.deinit();
+
+    try state.addInstance(component, name, .{
+        .version = "1.0.0",
+        .auto_start = false,
+        .launch_mode = "gateway",
+        .verbose = false,
+    });
+    try state.save();
+}
+
 test "integration harness serves health and core api routes" {
     var server = try IntegrationServer.start(std.testing.allocator);
     defer server.deinit();
 
     {
-        const resp = try server.fetch("/health");
+        const resp = try server.fetch(.{ .path = "/health" });
         defer resp.deinit(std.testing.allocator);
         try std.testing.expectEqual(std.http.Status.ok, resp.status);
     }
 
     {
-        const resp = try server.fetch("/api/status");
+        const resp = try server.fetch(.{ .path = "/api/status" });
         defer resp.deinit(std.testing.allocator);
         try std.testing.expectEqual(std.http.Status.ok, resp.status);
         try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"hub\"") != null);
@@ -148,8 +224,82 @@ test "integration harness serves health and core api routes" {
     }
 
     {
-        const resp = try server.fetch("/api/nonexistent");
+        const resp = try server.fetch(.{ .path = "/api/nonexistent" });
         defer resp.deinit(std.testing.allocator);
         try std.testing.expectEqual(std.http.Status.not_found, resp.status);
     }
+}
+
+test "integration harness covers settings and config round-trips" {
+    var server = try IntegrationServer.startWithSeed(std.testing.allocator, struct {
+        fn call(srv: *IntegrationServer) !void {
+            try seedManagedInstance(srv, "nullboiler", "demo");
+        }
+    }.call);
+    defer server.deinit();
+
+    {
+        const resp = try server.fetch(.{ .path = "/api/settings" });
+        defer resp.deinit(std.testing.allocator);
+        try std.testing.expectEqual(std.http.Status.ok, resp.status);
+        try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"port\":") != null);
+        try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"access\"") != null);
+    }
+
+    {
+        const resp = try server.fetch(.{
+            .path = "/api/settings",
+            .method = .PUT,
+            .body = "{\"port\":19901}",
+        });
+        defer resp.deinit(std.testing.allocator);
+        try std.testing.expectEqual(std.http.Status.ok, resp.status);
+        try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"status\":\"ok\"") != null);
+        try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"port\":19901") != null);
+    }
+
+    {
+        const resp = try server.fetch(.{ .path = "/api/instances" });
+        defer resp.deinit(std.testing.allocator);
+        try std.testing.expectEqual(std.http.Status.ok, resp.status);
+        try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"nullboiler\"") != null);
+        try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"demo\"") != null);
+    }
+
+    {
+        const resp = try server.fetch(.{
+            .path = "/api/instances/nullboiler/demo/config",
+            .method = .PUT,
+            .body = "{\"gateway\":{\"port\":43123},\"provider\":\"openrouter\"}",
+        });
+        defer resp.deinit(std.testing.allocator);
+        try std.testing.expectEqual(std.http.Status.ok, resp.status);
+        try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"status\":\"saved\"") != null);
+    }
+
+    {
+        const resp = try server.fetch(.{ .path = "/api/instances/nullboiler/demo/config" });
+        defer resp.deinit(std.testing.allocator);
+        try std.testing.expectEqual(std.http.Status.ok, resp.status);
+        try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"gateway\"") != null);
+        try std.testing.expect(std.mem.indexOf(u8, resp.body, "43123") != null);
+    }
+
+    {
+        const resp = try server.fetch(.{ .path = "/api/instances/nullboiler/demo/config?path=gateway.port" });
+        defer resp.deinit(std.testing.allocator);
+        try std.testing.expectEqual(std.http.Status.ok, resp.status);
+        try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"path\":\"gateway.port\"") != null);
+        try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"value\":43123") != null);
+    }
+}
+
+test "integration harness covers orchestration proxy not configured" {
+    var server = try IntegrationServer.start(std.testing.allocator);
+    defer server.deinit();
+
+    const resp = try server.fetch(.{ .path = "/api/orchestration/runs" });
+    defer resp.deinit(std.testing.allocator);
+    try std.testing.expectEqual(std.http.Status.service_unavailable, resp.status);
+    try std.testing.expect(std.mem.indexOf(u8, resp.body, "NullBoiler not configured") != null);
 }

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -1,0 +1,155 @@
+const std = @import("std");
+const std_compat = @import("compat");
+const builtin = @import("builtin");
+
+const IntegrationServer = struct {
+    allocator: std.mem.Allocator,
+    tmp_dir: std.testing.TmpDir,
+    temp_root: []const u8,
+    home_dir: []const u8,
+    port: u16,
+    child: std_compat.process.Child,
+    env_map: std_compat.process.EnvMap,
+
+    fn start(allocator: std.mem.Allocator) !IntegrationServer {
+        if (builtin.os.tag == .wasi) return error.SkipZigTest;
+
+        var tmp_dir = std.testing.tmpDir(.{});
+        errdefer tmp_dir.cleanup();
+
+        const temp_root = try std_compat.fs.Dir.wrap(tmp_dir.dir).realpathAlloc(allocator, ".");
+        errdefer allocator.free(temp_root);
+
+        const home_dir = try std.fs.path.join(allocator, &.{ temp_root, "home" });
+        errdefer allocator.free(home_dir);
+        try std_compat.fs.makeDirAbsolute(home_dir);
+
+        const port = try reservePort();
+        const port_text = try std.fmt.allocPrint(allocator, "{d}", .{port});
+        defer allocator.free(port_text);
+
+        const exe_path = try std_compat.process.getEnvVarOwned(allocator, "NULLHUB_INTEGRATION_BIN");
+        defer allocator.free(exe_path);
+
+        var env_map = try std_compat.process.getEnvMap(allocator);
+        errdefer env_map.deinit();
+        try env_map.put("HOME", home_dir);
+
+        const argv = try allocator.dupe([]const u8, &.{ exe_path, "serve", "--port", port_text, "--no-open" });
+        defer allocator.free(argv);
+
+        var child = std_compat.process.Child.init(argv, allocator);
+        child.cwd = ".";
+        child.env_map = &env_map;
+        child.stdin_behavior = .Ignore;
+        child.stdout_behavior = .Ignore;
+        child.stderr_behavior = .Ignore;
+        try child.spawn();
+        errdefer {
+            _ = child.kill() catch {};
+            _ = child.wait() catch {};
+        }
+
+        var server = IntegrationServer{
+            .allocator = allocator,
+            .tmp_dir = tmp_dir,
+            .temp_root = temp_root,
+            .home_dir = home_dir,
+            .port = port,
+            .child = child,
+            .env_map = env_map,
+        };
+        errdefer server.deinit();
+
+        try server.waitUntilReady();
+        return server;
+    }
+
+    fn deinit(self: *IntegrationServer) void {
+        _ = self.child.kill() catch {};
+        _ = self.child.wait() catch {};
+        self.env_map.deinit();
+        self.allocator.free(self.home_dir);
+        self.allocator.free(self.temp_root);
+        self.tmp_dir.cleanup();
+        self.* = undefined;
+    }
+
+    fn waitUntilReady(self: *IntegrationServer) !void {
+        var attempt: usize = 0;
+        while (attempt < 40) : (attempt += 1) {
+            const result = self.fetch("/health");
+            if (result) |resp| {
+                defer resp.deinit(self.allocator);
+                if (resp.status == .ok) return;
+            } else |_| {}
+
+            std_compat.thread.sleep(250 * std.time.ns_per_ms);
+        }
+
+        return error.ServerNotReady;
+    }
+
+    fn fetch(self: *IntegrationServer, path: []const u8) !HttpResponse {
+        const url = try std.fmt.allocPrint(self.allocator, "http://127.0.0.1:{d}{s}", .{ self.port, path });
+        defer self.allocator.free(url);
+
+        var client: std.http.Client = .{ .allocator = self.allocator, .io = std_compat.io() };
+        defer client.deinit();
+
+        var body: std.Io.Writer.Allocating = .init(self.allocator);
+        errdefer body.deinit();
+
+        const result = try client.fetch(.{
+            .location = .{ .url = url },
+            .method = .GET,
+            .response_writer = &body.writer,
+        });
+
+        return .{
+            .status = result.status,
+            .body = try body.toOwnedSlice(),
+        };
+    }
+};
+
+const HttpResponse = struct {
+    status: std.http.Status,
+    body: []u8,
+
+    fn deinit(self: HttpResponse, allocator: std.mem.Allocator) void {
+        allocator.free(self.body);
+    }
+};
+
+fn reservePort() !u16 {
+    const addr = try std_compat.net.Address.resolveIp("127.0.0.1", 0);
+    var listener = try addr.listen(.{});
+    defer listener.deinit();
+    return listener.listen_address.in.getPort();
+}
+
+test "integration harness serves health and core api routes" {
+    var server = try IntegrationServer.start(std.testing.allocator);
+    defer server.deinit();
+
+    {
+        const resp = try server.fetch("/health");
+        defer resp.deinit(std.testing.allocator);
+        try std.testing.expectEqual(std.http.Status.ok, resp.status);
+    }
+
+    {
+        const resp = try server.fetch("/api/status");
+        defer resp.deinit(std.testing.allocator);
+        try std.testing.expectEqual(std.http.Status.ok, resp.status);
+        try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"hub\"") != null);
+        try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"version\"") != null);
+    }
+
+    {
+        const resp = try server.fetch("/api/nonexistent");
+        defer resp.deinit(std.testing.allocator);
+        try std.testing.expectEqual(std.http.Status.not_found, resp.status);
+    }
+}

--- a/src/net_compat.zig
+++ b/src/net_compat.zig
@@ -1,67 +1,21 @@
-const std = @import("std");
 const std_compat = @import("compat");
-const builtin = @import("builtin");
 
-const windows_socket_error = -1;
-const wsaeconnaborted = 10053;
-const wsaeconnreset = 10054;
-const wsaenetreset = 10052;
-const wsaenotconn = 10057;
-const wsaetimedout = 10060;
-
-const ws2_32 = struct {
-    extern "ws2_32" fn recv(
-        socket: std.posix.socket_t,
-        buf: ?*anyopaque,
-        len: i32,
-        flags: i32,
-    ) callconv(std.builtin.CallingConvention.winapi) i32;
-
-    extern "ws2_32" fn send(
-        socket: std.posix.socket_t,
-        buf: ?*const anyopaque,
-        len: i32,
-        flags: i32,
-    ) callconv(std.builtin.CallingConvention.winapi) i32;
-
-    extern "ws2_32" fn WSAGetLastError() callconv(std.builtin.CallingConvention.winapi) i32;
-};
-
-/// Windows-safe socket read. Zig 0.15.2's std.net.Stream.read() uses
-/// NtReadFile/ReadFile on Windows, which fails on sockets with
-/// GetLastError(87) "The parameter is incorrect".
-///
-/// This wrapper uses ws2_32.recv on Windows and falls back to the
-/// standard stream.read() on other platforms.
+/// Socket read wrapper used by server code and tests.
 pub fn streamRead(stream: std_compat.net.Stream, buffer: []u8) !usize {
-    if (comptime builtin.os.tag == .windows) {
-        return windowsSocketRecv(stream.handle, buffer);
-    }
     return stream.read(buffer);
 }
 
-/// Windows-safe socket write. Same issue as read — uses ws2_32.send
-/// instead of WriteFile/NtWriteFile on Windows.
+/// Socket write wrapper used by server code and tests.
 pub fn streamWrite(stream: std_compat.net.Stream, data: []const u8) !usize {
-    if (comptime builtin.os.tag == .windows) {
-        return windowsSocketSend(stream.handle, data);
-    }
     return stream.write(data);
 }
 
-/// Write all data to a Windows socket.
+/// Write all data to a socket.
 pub fn streamWriteAll(stream: std_compat.net.Stream, data: []const u8) !void {
-    if (comptime builtin.os.tag == .windows) {
-        var offset: usize = 0;
-        while (offset < data.len) {
-            offset += try windowsSocketSend(stream.handle, data[offset..]);
-        }
-        return;
-    }
     return stream.writeAll(data);
 }
 
-/// A writer interface backed by Windows-safe socket writes.
+/// A writer interface backed by socket writes.
 pub const StreamWriter = struct {
     stream: std_compat.net.Stream,
 
@@ -76,36 +30,4 @@ pub const StreamWriter = struct {
 
 pub fn safeWriter(stream: std_compat.net.Stream) StreamWriter {
     return .{ .stream = stream };
-}
-
-// ── Windows socket internals ────────────────────────────────────────
-
-fn windowsSocketRecv(handle: std.os.windows.HANDLE, buffer: []u8) !usize {
-    const rc = ws2_32.recv(handle, buffer.ptr, @intCast(buffer.len), 0);
-    if (rc == windows_socket_error) {
-        const err = ws2_32.WSAGetLastError();
-        return switch (err) {
-            wsaeconnreset, wsaeconnaborted, wsaenetreset => error.ConnectionResetByPeer,
-            wsaetimedout => error.ConnectionTimedOut,
-            wsaenotconn => error.SocketNotConnected,
-            else => error.Unexpected,
-        };
-    }
-    const bytes: usize = @intCast(rc);
-    if (bytes == 0) return 0; // clean close
-    return bytes;
-}
-
-fn windowsSocketSend(handle: std.os.windows.HANDLE, data: []const u8) !usize {
-    const rc = ws2_32.send(handle, data.ptr, @intCast(data.len), 0);
-    if (rc == windows_socket_error) {
-        const err = ws2_32.WSAGetLastError();
-        return switch (err) {
-            wsaeconnreset, wsaeconnaborted, wsaenetreset => error.ConnectionResetByPeer,
-            wsaetimedout => error.ConnectionTimedOut,
-            wsaenotconn => error.SocketNotConnected,
-            else => error.Unexpected,
-        };
-    }
-    return @intCast(rc);
 }

--- a/src/server.zig
+++ b/src/server.zig
@@ -418,14 +418,17 @@ pub const Server = struct {
                 std.debug.print("accept error: {}\n", .{err});
                 continue;
             };
-            defer conn.stream.close();
 
-            var arena = std.heap.ArenaAllocator.init(self.allocator);
-            defer arena.deinit();
+            {
+                defer conn.stream.close();
 
-            self.handleConnection(conn, arena.allocator()) catch |err| {
-                std.debug.print("request error: {}\n", .{err});
-            };
+                var arena = std.heap.ArenaAllocator.init(self.allocator);
+                defer arena.deinit();
+
+                self.handleConnection(conn, arena.allocator()) catch |err| {
+                    std.debug.print("request error: {}\n", .{err});
+                };
+            }
         }
     }
 
@@ -1198,6 +1201,12 @@ fn sendResponse(stream: std_compat.net.Stream, response: Response, raw_request: 
     try writer.print("Content-Length: {d}\r\n", .{response.body.len});
     try appendCorsHeaders(&writer, raw_request, bind_host, port, extra_origins);
     try writer.writeAll("Connection: close\r\n\r\n");
+
+    if (response.body.len <= buf.len - writer.buffered().len) {
+        try writer.writeAll(response.body);
+        try net_compat.streamWriteAll(stream, writer.buffered());
+        return;
+    }
 
     try net_compat.streamWriteAll(stream, writer.buffered());
     if (response.body.len > 0) {

--- a/tests/test_backend.sh
+++ b/tests/test_backend.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_with_timeout() {
+  if command -v timeout >/dev/null 2>&1 && timeout --version >/dev/null 2>&1; then
+    timeout 300s "$@"
+  else
+    "$@"
+  fi
+}
+
+zig build test -Dembed-ui=false -Dbuild-ui=false --summary all
+run_with_timeout zig build test-integration -Dembed-ui=false -Dbuild-ui=false --summary all


### PR DESCRIPTION
## Summary

- add a dedicated `zig build test-integration` step for structured backend integration coverage without replacing the existing unit-test gate
- introduce a first integration harness that builds the real `nullhub` binary, starts it under a temporary home directory, and performs HTTP assertions with Zig's HTTP client
- cover the initial smoke-style routes in structured form: `/health`, `/api/status`, and a representative 404 path

## Validation

- `zig build test -Dembed-ui=false -Dbuild-ui=false --summary all`
- `zig build test-integration -Dembed-ui=false -Dbuild-ui=false --summary all`
- `npm --prefix ui ci --no-audit --no-fund`
- `npm --prefix ui run build`
- `bash tests/test_e2e.sh`
- `zig fmt --check src/`
- `git diff --check`

## Notes

- this is intentionally the first small harness slice, not the full integration suite; later slices can add instance lifecycle, config mutation, and orchestration flows on top of the same test entrypoint
- the shell smoke test remains in place and unchanged; this adds a structured Zig integration layer rather than replacing the shell coverage immediately