### PR TITLE
fix(ui): install chat modules from released archives

### DIFF
--- a/src/fs_compat.zig
+++ b/src/fs_compat.zig
@@ -142,6 +142,35 @@ pub fn appendLine(path: []const u8, line: []const u8) !void {
     try file.writeAll("\n");
 }
 
+pub fn copyDirectoryContents(allocator: std.mem.Allocator, source_dir_path: []const u8, dest_dir_path: []const u8) !void {
+    try makePath(dest_dir_path);
+
+    var source_dir = try std_compat.fs.openDirAbsolute(source_dir_path, .{ .iterate = true });
+    defer source_dir.close();
+
+    var walker = try source_dir.walk(allocator);
+    defer walker.deinit();
+
+    while (try walker.next()) |entry| {
+        const dest_path = try std.fs.path.join(allocator, &.{ dest_dir_path, entry.path });
+        defer allocator.free(dest_path);
+
+        switch (entry.kind) {
+            .directory => try makePath(dest_path),
+            .file => {
+                if (std.fs.path.dirname(dest_path)) |dest_parent| {
+                    try makePath(dest_parent);
+                }
+
+                const source_path = try std.fs.path.join(allocator, &.{ source_dir_path, entry.path });
+                defer allocator.free(source_path);
+                try std_compat.fs.copyFileAbsolute(source_path, dest_path, .{});
+            },
+            else => return error.UnsupportedFileKind,
+        }
+    }
+}
+
 test "readFileAlloc reads file contents" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();

--- a/src/installer/orchestrator.zig
+++ b/src/installer/orchestrator.zig
@@ -1082,35 +1082,6 @@ fn npmCommand() []const u8 {
     return if (builtin.os.tag == .windows) "npm.cmd" else "npm";
 }
 
-fn copyDirectoryContents(allocator: std.mem.Allocator, source_dir_path: []const u8, dest_dir_path: []const u8) !void {
-    try fs_compat.makePath(dest_dir_path);
-
-    var source_dir = try std_compat.fs.openDirAbsolute(source_dir_path, .{ .iterate = true });
-    defer source_dir.close();
-
-    var walker = try source_dir.walk(allocator);
-    defer walker.deinit();
-
-    while (try walker.next()) |entry| {
-        const dest_path = try std.fs.path.join(allocator, &.{ dest_dir_path, entry.path });
-        defer allocator.free(dest_path);
-
-        switch (entry.kind) {
-            .directory => try fs_compat.makePath(dest_path),
-            .file => {
-                if (std.fs.path.dirname(dest_path)) |dest_parent| {
-                    try fs_compat.makePath(dest_parent);
-                }
-
-                const source_path = try std.fs.path.join(allocator, &.{ source_dir_path, entry.path });
-                defer allocator.free(source_path);
-                try std_compat.fs.copyFileAbsolute(source_path, dest_path, .{});
-            },
-            else => return error.UnsupportedFileKind,
-        }
-    }
-}
-
 fn buildLocalUiModuleFromDir(allocator: std.mem.Allocator, module_dir: []const u8, dest_dir: []const u8) bool {
     std.debug.print("Building UI module from local source: {s}\n", .{module_dir});
 
@@ -1138,7 +1109,7 @@ fn buildLocalUiModuleFromDir(allocator: std.mem.Allocator, module_dir: []const u
     const dist_path = std.fs.path.join(allocator, &.{ module_dir, "dist" }) catch return false;
     defer allocator.free(dist_path);
 
-    copyDirectoryContents(allocator, dist_path, dest_dir) catch |err| {
+    fs_compat.copyDirectoryContents(allocator, dist_path, dest_dir) catch |err| {
         std.debug.print("UI module copy failed ({s})\n", .{@errorName(err)});
         return false;
     };
@@ -1420,7 +1391,7 @@ test "copyDirectoryContents recursively copies nested files" {
     try writeFile(top_level_file, "console.log('root');");
     try writeFile(nested_file, "console.log('nested');");
 
-    try copyDirectoryContents(allocator, source_dir, dest_dir);
+    try fs_compat.copyDirectoryContents(allocator, source_dir, dest_dir);
 
     const copied_top_level = try std.fs.path.join(allocator, &.{ dest_dir, "index.js" });
     defer allocator.free(copied_top_level);

--- a/src/installer/ui_modules.zig
+++ b/src/installer/ui_modules.zig
@@ -29,6 +29,28 @@ pub fn buildBundleAssetUrl(
     );
 }
 
+fn findUiModuleArchiveAsset(
+    allocator: std.mem.Allocator,
+    release: registry.ReleaseInfo,
+    module_name: []const u8,
+) ?registry.AssetInfo {
+    const preferred_bundle = std.fmt.allocPrint(allocator, "{s}-bundle.tar.gz", .{module_name}) catch return null;
+    defer allocator.free(preferred_bundle);
+    if (registry.findAssetByName(release, preferred_bundle)) |asset| return asset;
+
+    const release_archive = std.fmt.allocPrint(allocator, "{s}-{s}.tar.gz", .{ module_name, release.tag_name }) catch return null;
+    defer allocator.free(release_archive);
+    if (registry.findAssetByName(release, release_archive)) |asset| return asset;
+
+    for (release.assets) |asset| {
+        if (std.mem.startsWith(u8, asset.name, module_name) and std.mem.endsWith(u8, asset.name, ".tar.gz")) {
+            return asset;
+        }
+    }
+
+    return null;
+}
+
 // ─── Extraction ──────────────────────────────────────────────────────────────
 
 /// Extract a `.tar.gz` archive to the specified destination directory.
@@ -79,6 +101,63 @@ pub fn isModuleInstalled(dest_dir: []const u8) bool {
     return true;
 }
 
+fn copyDirectoryContents(allocator: std.mem.Allocator, source_dir_path: []const u8, dest_dir_path: []const u8) !void {
+    try std_compat.fs.makeDirAbsolute(dest_dir_path);
+
+    var source_dir = try std_compat.fs.openDirAbsolute(source_dir_path, .{ .iterate = true });
+    defer source_dir.close();
+
+    var walker = try source_dir.walk(allocator);
+    defer walker.deinit();
+
+    while (try walker.next()) |entry| {
+        const dest_path = try std.fs.path.join(allocator, &.{ dest_dir_path, entry.path });
+        defer allocator.free(dest_path);
+
+        switch (entry.kind) {
+            .directory => try std_compat.fs.makeDirAbsolute(dest_path),
+            .file => {
+                if (std.fs.path.dirname(dest_path)) |dest_parent| {
+                    try std_compat.fs.makeDirAbsolute(dest_parent);
+                }
+
+                const source_path = try std.fs.path.join(allocator, &.{ source_dir_path, entry.path });
+                defer allocator.free(source_path);
+                try std_compat.fs.copyFileAbsolute(source_path, dest_path, .{});
+            },
+            else => return error.UnsupportedFileKind,
+        }
+    }
+}
+
+fn resolveExtractedModuleRoot(allocator: std.mem.Allocator, extract_dir: []const u8) ![]const u8 {
+    var dir = try std_compat.fs.openDirAbsolute(extract_dir, .{ .iterate = true });
+    defer dir.close();
+
+    var it = dir.iterate();
+    var entry_count: usize = 0;
+    var single_dir_name: ?[]u8 = null;
+    defer if (single_dir_name) |name| allocator.free(name);
+
+    while (try it.next()) |entry| {
+        entry_count += 1;
+        if (entry_count != 1 or entry.kind != .directory) continue;
+        single_dir_name = try allocator.dupe(u8, entry.name);
+    }
+
+    if (entry_count == 1 and single_dir_name != null) {
+        return std.fs.path.join(allocator, &.{ extract_dir, single_dir_name.? });
+    }
+    return allocator.dupe(u8, extract_dir);
+}
+
+fn installExtractedUiModule(allocator: std.mem.Allocator, extract_dir: []const u8, dest_dir: []const u8) !void {
+    const source_root = try resolveExtractedModuleRoot(allocator, extract_dir);
+    defer allocator.free(source_root);
+
+    try copyDirectoryContents(allocator, source_root, dest_dir);
+}
+
 // ─── Download ────────────────────────────────────────────────────────────────
 
 /// Download and extract a UI module bundle.
@@ -94,10 +173,19 @@ pub fn downloadUiModule(
     version: []const u8,
     dest_dir: []const u8,
 ) !void {
-    const url = try buildBundleAssetUrl(allocator, repo, version, module_name);
-    defer allocator.free(url);
+    var release = if (std.mem.eql(u8, version, "latest"))
+        try registry.fetchLatestRelease(allocator, repo)
+    else
+        try registry.fetchReleaseByTag(allocator, repo, version);
+    defer release.deinit();
+
+    const asset = findUiModuleArchiveAsset(allocator, release.value, module_name) orelse return error.AssetNotFound;
 
     // Ensure dest_dir exists before downloading into it.
+    std_compat.fs.deleteTreeAbsolute(dest_dir) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
     std_compat.fs.makeDirAbsolute(dest_dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
         error.FileNotFound => {
@@ -111,13 +199,22 @@ pub fn downloadUiModule(
         else => return err,
     };
 
-    const archive_path = try std.fmt.allocPrint(allocator, "{s}/{s}-bundle.tar.gz", .{ dest_dir, module_name });
+    const archive_path = try std.fmt.allocPrint(allocator, "{s}.download.tar.gz", .{dest_dir});
     defer allocator.free(archive_path);
 
-    try downloader.download(allocator, url, archive_path);
+    try downloader.download(allocator, asset.browser_download_url, archive_path);
     defer std_compat.fs.deleteFileAbsolute(archive_path) catch {};
 
-    try extractTarGz(allocator, archive_path, dest_dir);
+    const extract_dir = try std.fmt.allocPrint(allocator, "{s}.extract", .{dest_dir});
+    defer allocator.free(extract_dir);
+    std_compat.fs.deleteTreeAbsolute(extract_dir) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
+    defer std_compat.fs.deleteTreeAbsolute(extract_dir) catch {};
+
+    try extractTarGz(allocator, archive_path, extract_dir);
+    try installExtractedUiModule(allocator, extract_dir, dest_dir);
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -140,6 +237,34 @@ test "buildBundleAssetUrl with different module" {
         "https://github.com/nullclaw/dashboard/releases/download/v3.0.0/dashboard-bundle.tar.gz",
         url,
     );
+}
+
+test "findUiModuleArchiveAsset prefers bundle asset" {
+    const allocator = std.testing.allocator;
+    const release = registry.ReleaseInfo{
+        .tag_name = "v2026.3.4",
+        .assets = &.{
+            .{ .name = "nullclaw-chat-ui-v2026.3.4.tar.gz", .browser_download_url = "https://example.com/release.tar.gz" },
+            .{ .name = "nullclaw-chat-ui-bundle.tar.gz", .browser_download_url = "https://example.com/bundle.tar.gz" },
+        },
+    };
+
+    const asset = findUiModuleArchiveAsset(allocator, release, "nullclaw-chat-ui") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("nullclaw-chat-ui-bundle.tar.gz", asset.name);
+}
+
+test "findUiModuleArchiveAsset falls back to versioned release tarball" {
+    const allocator = std.testing.allocator;
+    const release = registry.ReleaseInfo{
+        .tag_name = "v2026.3.4",
+        .assets = &.{
+            .{ .name = "nullclaw-chat-ui-v2026.3.4.tar.gz", .browser_download_url = "https://example.com/release.tar.gz" },
+            .{ .name = "nullclaw-chat-ui-v2026.3.4.zip", .browser_download_url = "https://example.com/release.zip" },
+        },
+    };
+
+    const asset = findUiModuleArchiveAsset(allocator, release, "nullclaw-chat-ui") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("nullclaw-chat-ui-v2026.3.4.tar.gz", asset.name);
 }
 
 test "extractTarGz creates dest_dir and extracts contents" {
@@ -189,6 +314,43 @@ test "extractTarGz creates dest_dir and extracts contents" {
     var buf: [256]u8 = undefined;
     const n = try file.readAll(&buf);
     try std.testing.expectEqualStrings("<html><body>Hello</body></html>", buf[0..n]);
+}
+
+test "installExtractedUiModule flattens single top-level archive directory" {
+    const allocator = std.testing.allocator;
+
+    const tmp_dir = "/tmp/test-nullhub-ui-install-extracted";
+    std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    try std_compat.fs.makeDirAbsolute(tmp_dir);
+    defer std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+
+    const extract_dir = try std.fmt.allocPrint(allocator, "{s}/extract", .{tmp_dir});
+    defer allocator.free(extract_dir);
+    const nested_dir = try std.fmt.allocPrint(allocator, "{s}/nullclaw-chat-ui", .{extract_dir});
+    defer allocator.free(nested_dir);
+    const dest_dir = try std.fmt.allocPrint(allocator, "{s}/dest", .{tmp_dir});
+    defer allocator.free(dest_dir);
+
+    try std_compat.fs.makeDirAbsolute(nested_dir);
+    try std_compat.fs.makeDirAbsolute(dest_dir);
+
+    const module_path = try std.fmt.allocPrint(allocator, "{s}/module.js", .{nested_dir});
+    defer allocator.free(module_path);
+    {
+        var file = try std_compat.fs.createFileAbsolute(module_path, .{});
+        defer file.close();
+        try file.writeAll("export const ok = true;\n");
+    }
+
+    try installExtractedUiModule(allocator, extract_dir, dest_dir);
+
+    const installed_path = try std.fmt.allocPrint(allocator, "{s}/module.js", .{dest_dir});
+    defer allocator.free(installed_path);
+    var file = try std_compat.fs.openFileAbsolute(installed_path, .{});
+    defer file.close();
+    var buf: [64]u8 = undefined;
+    const n = try file.readAll(&buf);
+    try std.testing.expectEqualStrings("export const ok = true;\n", buf[0..n]);
 }
 
 test "isModuleInstalled returns true for existing directory" {

--- a/src/installer/ui_modules.zig
+++ b/src/installer/ui_modules.zig
@@ -3,6 +3,7 @@ const std_compat = @import("compat");
 const registry = @import("registry.zig");
 const downloader = @import("downloader.zig");
 const prereqs = @import("prereqs.zig");
+const fs_compat = @import("../fs_compat.zig");
 
 // ─── Errors ──────────────────────────────────────────────────────────────────
 
@@ -10,24 +11,6 @@ pub const UiModuleError = error{
     ExtractionFailed,
     AssetNotFound,
 };
-
-// ─── URL building ────────────────────────────────────────────────────────────
-
-/// Build the download URL for a UI module bundle asset from a GitHub release.
-/// The asset name follows the convention `{module-name}-bundle.tar.gz`.
-/// Caller owns the returned memory.
-pub fn buildBundleAssetUrl(
-    allocator: std.mem.Allocator,
-    repo: []const u8,
-    version: []const u8,
-    module_name: []const u8,
-) ![]const u8 {
-    return std.fmt.allocPrint(
-        allocator,
-        "https://github.com/{s}/releases/download/{s}/{s}-bundle.tar.gz",
-        .{ repo, version, module_name },
-    );
-}
 
 fn findUiModuleArchiveAsset(
     allocator: std.mem.Allocator,
@@ -43,12 +26,20 @@ fn findUiModuleArchiveAsset(
     if (registry.findAssetByName(release, release_archive)) |asset| return asset;
 
     for (release.assets) |asset| {
-        if (std.mem.startsWith(u8, asset.name, module_name) and std.mem.endsWith(u8, asset.name, ".tar.gz")) {
+        if (isUiModuleArchiveAssetName(asset.name, module_name)) {
             return asset;
         }
     }
 
     return null;
+}
+
+fn isUiModuleArchiveAssetName(asset_name: []const u8, module_name: []const u8) bool {
+    if (!std.mem.startsWith(u8, asset_name, module_name)) return false;
+    if (!std.mem.endsWith(u8, asset_name, ".tar.gz")) return false;
+
+    const suffix = asset_name[module_name.len..];
+    return std.mem.eql(u8, suffix, ".tar.gz") or std.mem.startsWith(u8, suffix, "-");
 }
 
 // ─── Extraction ──────────────────────────────────────────────────────────────
@@ -60,20 +51,7 @@ fn findUiModuleArchiveAsset(
 pub fn extractTarGz(allocator: std.mem.Allocator, archive_path: []const u8, dest_dir: []const u8) !void {
     prereqs.ensureTool(allocator, "tar") catch return error.ExtractionFailed;
 
-    // Create dest_dir if it doesn't exist.
-    std_compat.fs.makeDirAbsolute(dest_dir) catch |err| switch (err) {
-        error.PathAlreadyExists => {},
-        error.FileNotFound => {
-            // Parent directory missing — create the full path.
-            if (std.fs.path.dirnamePosix(dest_dir)) |parent| {
-                try std_compat.fs.makeDirAbsolute(parent);
-                try std_compat.fs.makeDirAbsolute(dest_dir);
-            } else {
-                return err;
-            }
-        },
-        else => return err,
-    };
+    try fs_compat.makePath(dest_dir);
 
     const result = std_compat.process.Child.run(.{
         .allocator = allocator,
@@ -92,42 +70,16 @@ pub fn extractTarGz(allocator: std.mem.Allocator, archive_path: []const u8, dest
 
 // ─── Module status ───────────────────────────────────────────────────────────
 
-/// Check whether a UI module is installed at the given directory.
+/// Check whether a UI module entrypoint is installed at the given directory.
 ///
-/// Returns `true` if `dest_dir` exists and is accessible as a directory.
+/// Returns `true` only when `module.js` exists where the frontend imports it.
 pub fn isModuleInstalled(dest_dir: []const u8) bool {
     var dir = std_compat.fs.openDirAbsolute(dest_dir, .{}) catch return false;
-    dir.close();
+    defer dir.close();
+
+    const file = dir.openFile("module.js", .{}) catch return false;
+    file.close();
     return true;
-}
-
-fn copyDirectoryContents(allocator: std.mem.Allocator, source_dir_path: []const u8, dest_dir_path: []const u8) !void {
-    try std_compat.fs.makeDirAbsolute(dest_dir_path);
-
-    var source_dir = try std_compat.fs.openDirAbsolute(source_dir_path, .{ .iterate = true });
-    defer source_dir.close();
-
-    var walker = try source_dir.walk(allocator);
-    defer walker.deinit();
-
-    while (try walker.next()) |entry| {
-        const dest_path = try std.fs.path.join(allocator, &.{ dest_dir_path, entry.path });
-        defer allocator.free(dest_path);
-
-        switch (entry.kind) {
-            .directory => try std_compat.fs.makeDirAbsolute(dest_path),
-            .file => {
-                if (std.fs.path.dirname(dest_path)) |dest_parent| {
-                    try std_compat.fs.makeDirAbsolute(dest_parent);
-                }
-
-                const source_path = try std.fs.path.join(allocator, &.{ source_dir_path, entry.path });
-                defer allocator.free(source_path);
-                try std_compat.fs.copyFileAbsolute(source_path, dest_path, .{});
-            },
-            else => return error.UnsupportedFileKind,
-        }
-    }
 }
 
 fn resolveExtractedModuleRoot(allocator: std.mem.Allocator, extract_dir: []const u8) ![]const u8 {
@@ -155,17 +107,17 @@ fn installExtractedUiModule(allocator: std.mem.Allocator, extract_dir: []const u
     const source_root = try resolveExtractedModuleRoot(allocator, extract_dir);
     defer allocator.free(source_root);
 
-    try copyDirectoryContents(allocator, source_root, dest_dir);
+    try fs_compat.copyDirectoryContents(allocator, source_root, dest_dir);
 }
 
 // ─── Download ────────────────────────────────────────────────────────────────
 
-/// Download and extract a UI module bundle.
+/// Download and extract a UI module release archive.
 ///
-/// 1. Builds the GitHub release download URL for the module's tarball.
-/// 2. Downloads the tarball to a temporary path under `dest_dir`.
-/// 3. Extracts the tarball into `dest_dir`.
-/// 4. Removes the temporary tarball after extraction.
+/// 1. Resolves GitHub release metadata for `version`.
+/// 2. Selects a compatible `.tar.gz` release asset.
+/// 3. Downloads the tarball to a temporary path next to `dest_dir`.
+/// 4. Extracts and normalizes the archive layout into `dest_dir`.
 pub fn downloadUiModule(
     allocator: std.mem.Allocator,
     repo: []const u8,
@@ -181,23 +133,11 @@ pub fn downloadUiModule(
 
     const asset = findUiModuleArchiveAsset(allocator, release.value, module_name) orelse return error.AssetNotFound;
 
-    // Ensure dest_dir exists before downloading into it.
     std_compat.fs.deleteTreeAbsolute(dest_dir) catch |err| switch (err) {
         error.FileNotFound => {},
         else => return err,
     };
-    std_compat.fs.makeDirAbsolute(dest_dir) catch |err| switch (err) {
-        error.PathAlreadyExists => {},
-        error.FileNotFound => {
-            if (std.fs.path.dirnamePosix(dest_dir)) |parent| {
-                try std_compat.fs.makeDirAbsolute(parent);
-                try std_compat.fs.makeDirAbsolute(dest_dir);
-            } else {
-                return err;
-            }
-        },
-        else => return err,
-    };
+    try fs_compat.makePath(dest_dir);
 
     const archive_path = try std.fmt.allocPrint(allocator, "{s}.download.tar.gz", .{dest_dir});
     defer allocator.free(archive_path);
@@ -218,26 +158,6 @@ pub fn downloadUiModule(
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
-
-test "buildBundleAssetUrl produces correct URL" {
-    const allocator = std.testing.allocator;
-    const url = try buildBundleAssetUrl(allocator, "nullclaw/chat-ui", "v1.2.0", "chat-ui");
-    defer allocator.free(url);
-    try std.testing.expectEqualStrings(
-        "https://github.com/nullclaw/chat-ui/releases/download/v1.2.0/chat-ui-bundle.tar.gz",
-        url,
-    );
-}
-
-test "buildBundleAssetUrl with different module" {
-    const allocator = std.testing.allocator;
-    const url = try buildBundleAssetUrl(allocator, "nullclaw/dashboard", "v3.0.0", "dashboard");
-    defer allocator.free(url);
-    try std.testing.expectEqualStrings(
-        "https://github.com/nullclaw/dashboard/releases/download/v3.0.0/dashboard-bundle.tar.gz",
-        url,
-    );
-}
 
 test "findUiModuleArchiveAsset prefers bundle asset" {
     const allocator = std.testing.allocator;
@@ -265,6 +185,18 @@ test "findUiModuleArchiveAsset falls back to versioned release tarball" {
 
     const asset = findUiModuleArchiveAsset(allocator, release, "nullclaw-chat-ui") orelse return error.TestUnexpectedResult;
     try std.testing.expectEqualStrings("nullclaw-chat-ui-v2026.3.4.tar.gz", asset.name);
+}
+
+test "findUiModuleArchiveAsset does not match a different module prefix" {
+    const allocator = std.testing.allocator;
+    const release = registry.ReleaseInfo{
+        .tag_name = "v2026.3.4",
+        .assets = &.{
+            .{ .name = "nullclaw-chat-uikit-v2026.3.4.tar.gz", .browser_download_url = "https://example.com/uikit.tar.gz" },
+        },
+    };
+
+    try std.testing.expect(findUiModuleArchiveAsset(allocator, release, "nullclaw-chat-ui") == null);
 }
 
 test "extractTarGz creates dest_dir and extracts contents" {
@@ -353,13 +285,30 @@ test "installExtractedUiModule flattens single top-level archive directory" {
     try std.testing.expectEqualStrings("export const ok = true;\n", buf[0..n]);
 }
 
-test "isModuleInstalled returns true for existing directory" {
+test "isModuleInstalled returns true when module entrypoint exists" {
     const tmp_dir = "/tmp/test-nullhub-ui-installed";
     std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
     try std_compat.fs.makeDirAbsolute(tmp_dir);
     defer std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
 
+    const module_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/module.js", .{tmp_dir});
+    defer std.testing.allocator.free(module_path);
+    {
+        var file = try std_compat.fs.createFileAbsolute(module_path, .{});
+        defer file.close();
+        try file.writeAll("export {};\n");
+    }
+
     try std.testing.expect(isModuleInstalled(tmp_dir));
+}
+
+test "isModuleInstalled returns false without module entrypoint" {
+    const tmp_dir = "/tmp/test-nullhub-ui-installed-no-entrypoint";
+    std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    try std_compat.fs.makeDirAbsolute(tmp_dir);
+    defer std_compat.fs.deleteTreeAbsolute(tmp_dir) catch {};
+
+    try std.testing.expect(!isModuleInstalled(tmp_dir));
 }
 
 test "isModuleInstalled returns false for non-existing directory" {

--- a/src/server.zig
+++ b/src/server.zig
@@ -239,6 +239,10 @@ pub const Server = struct {
             const mod_version = entry.name[at_idx + 1 ..];
             if (mod_name.len == 0 or mod_version.len == 0) continue;
 
+            const module_dir = std.fs.path.join(allocator, &.{ ui_path, entry.name }) catch continue;
+            defer allocator.free(module_dir);
+            if (!ui_modules.isModuleInstalled(module_dir)) continue;
+
             var existing_index: ?usize = null;
             for (modules.items, 0..) |existing, index| {
                 if (std.mem.eql(u8, existing.name, mod_name)) {
@@ -1396,6 +1400,15 @@ const TestContext = struct {
     }
 };
 
+fn writeUiModuleEntrypoint(allocator: std.mem.Allocator, module_dir: []const u8) !void {
+    const module_path = try std.fs.path.join(allocator, &.{ module_dir, "module.js" });
+    defer allocator.free(module_path);
+
+    var file = try std_compat.fs.createFileAbsolute(module_path, .{});
+    defer file.close();
+    try file.writeAll("export {};\n");
+}
+
 // --- Tests ---
 
 test "route GET /health returns 200 OK" {
@@ -1874,14 +1887,21 @@ test "route GET /api/ui-modules prefers dev-local and deduplicates module versio
     const release_dir = try ctx.paths.uiModule(std.testing.allocator, "nullclaw-chat-ui", "v2026.3.1");
     defer std.testing.allocator.free(release_dir);
     try std_compat.fs.makeDirAbsolute(release_dir);
+    try writeUiModuleEntrypoint(std.testing.allocator, release_dir);
 
     const dev_local_dir = try ctx.paths.uiModule(std.testing.allocator, "nullclaw-chat-ui", "dev-local");
     defer std.testing.allocator.free(dev_local_dir);
     try std_compat.fs.makeDirAbsolute(dev_local_dir);
+    try writeUiModuleEntrypoint(std.testing.allocator, dev_local_dir);
 
     const other_release_dir = try ctx.paths.uiModule(std.testing.allocator, "other-ui", "v1.0.0");
     defer std.testing.allocator.free(other_release_dir);
     try std_compat.fs.makeDirAbsolute(other_release_dir);
+    try writeUiModuleEntrypoint(std.testing.allocator, other_release_dir);
+
+    const broken_release_dir = try ctx.paths.uiModule(std.testing.allocator, "broken-ui", "v1.0.0");
+    defer std.testing.allocator.free(broken_release_dir);
+    try std_compat.fs.makeDirAbsolute(broken_release_dir);
 
     const resp = ctx.route(std.testing.allocator, "GET", "/api/ui-modules", "");
     defer std.testing.allocator.free(resp.body);
@@ -1890,6 +1910,7 @@ test "route GET /api/ui-modules prefers dev-local and deduplicates module versio
     try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"nullclaw-chat-ui\":\"dev-local\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"nullclaw-chat-ui\":\"v2026.3.1\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"other-ui\":\"v1.0.0\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"broken-ui\"") == null);
 }
 
 test "route POST /api/instances/{component}/{name}/start returns 500 without binary" {


### PR DESCRIPTION
## Summary
- resolve actual UI module release assets from GitHub release metadata instead of assuming only `*-bundle.tar.gz`
- accept the current `nullclaw-chat-ui-<tag>.tar.gz` archive naming used by `nullclaw-chat-ui` releases
- flatten extracted archives when they contain a single top-level directory so installed files land at the module root where NullHub expects `module.js`
- add focused tests for asset selection and extracted-layout normalization

## Why
NullHub's chat tab dynamically imports `/ui/<module>@<version>/module.js`. Recent `nullclaw-chat-ui` releases published archives containing a top-level package directory and no `*-bundle.tar.gz` asset, so NullHub could install a module directory but still fail to serve the embeddable entrypoint where the UI expected it. That left the chat tab stuck on `Failed to load module: Importing a module script failed.`

## Validation
- `zig build test -Dbuild-ui=false -Dembed-ui=false --summary all`
- local live smoke after rebuild/restart:
  - `GET /api/ui-modules`
  - `GET /ui/nullclaw-chat-ui@latest/module.js` -> `200 OK`
  - confirmed chat tabs for `default` and `willy-nilly` load once the fixed chat-ui release layout is installed

## Notes
- this is the NullHub-side compatibility half of the chat fix
- the corresponding `nullclaw-chat-ui` release packaging fix is submitted separately