### PR TITLE
fix(instances): report imported standalone live status

### DIFF
--- a/src/api/instance_runtime.zig
+++ b/src/api/instance_runtime.zig
@@ -1,0 +1,131 @@
+const std = @import("std");
+const std_compat = @import("compat");
+const state_mod = @import("../core/state.zig");
+const manager_mod = @import("../supervisor/manager.zig");
+const paths_mod = @import("../core/paths.zig");
+const health_mod = @import("../supervisor/health.zig");
+
+pub const Snapshot = struct {
+    status: manager_mod.Status,
+    pid: ?std_compat.process.Child.Id = null,
+    uptime_seconds: ?u64 = null,
+    restart_count: u32 = 0,
+    port: u16 = 0,
+};
+
+fn snapshotFromManager(status: manager_mod.InstanceStatus) Snapshot {
+    return .{
+        .status = status.status,
+        .pid = status.pid,
+        .uptime_seconds = status.uptime_seconds,
+        .restart_count = status.restart_count,
+        .port = status.port,
+    };
+}
+
+/// Read a port value from an instance's config.json using a dot-separated key
+/// (e.g. "gateway.port" -> config["gateway"]["port"]).
+pub fn readPortFromConfig(allocator: std.mem.Allocator, paths: paths_mod.Paths, component: []const u8, name: []const u8, dot_key: []const u8) ?u16 {
+    const config_path = paths.instanceConfig(allocator, component, name) catch return null;
+    defer allocator.free(config_path);
+
+    const file = std_compat.fs.openFileAbsolute(config_path, .{}) catch return null;
+    defer file.close();
+    const contents = file.readToEndAlloc(allocator, 4 * 1024 * 1024) catch return null;
+    defer allocator.free(contents);
+
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, contents, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    }) catch return null;
+    defer parsed.deinit();
+
+    var current = parsed.value;
+    var it = std.mem.splitScalar(u8, dot_key, '.');
+    while (it.next()) |segment| {
+        switch (current) {
+            .object => |obj| current = obj.get(segment) orelse return null,
+            else => return null,
+        }
+    }
+
+    return switch (current) {
+        .integer => |value| if (value >= 0 and value <= 65535) @intCast(value) else null,
+        else => null,
+    };
+}
+
+fn isImportedStandalone(
+    allocator: std.mem.Allocator,
+    paths: paths_mod.Paths,
+    component: []const u8,
+    name: []const u8,
+    entry: state_mod.InstanceEntry,
+) bool {
+    if (!std.mem.eql(u8, component, "nullclaw")) return false;
+    if (!std.mem.eql(u8, entry.launch_mode, "gateway")) return false;
+
+    const inst_dir = paths.instanceDir(allocator, component, name) catch return false;
+    defer allocator.free(inst_dir);
+    const real_dir = std_compat.fs.realpathAlloc(allocator, inst_dir) catch return false;
+    defer allocator.free(real_dir);
+
+    const home = std_compat.process.getEnvVarOwned(allocator, "HOME") catch
+        std_compat.process.getEnvVarOwned(allocator, "USERPROFILE") catch return false;
+    defer allocator.free(home);
+    const standalone_root = std.fmt.allocPrint(allocator, "{s}/.{s}", .{ home, component }) catch return false;
+    defer allocator.free(standalone_root);
+    const real_standalone_root = std_compat.fs.realpathAlloc(allocator, standalone_root) catch return false;
+    defer allocator.free(real_standalone_root);
+
+    return std.mem.eql(u8, real_dir, real_standalone_root);
+}
+
+fn standaloneStatus(manager_snapshot: ?Snapshot, live_ok: bool) manager_mod.Status {
+    if (live_ok) return .running;
+    if (manager_snapshot) |snapshot| {
+        return switch (snapshot.status) {
+            .starting, .restarting, .stopping => snapshot.status,
+            .running, .failed, .stopped => .stopped,
+        };
+    }
+    return .stopped;
+}
+
+fn deriveImportedStandaloneSnapshot(
+    allocator: std.mem.Allocator,
+    paths: paths_mod.Paths,
+    component: []const u8,
+    name: []const u8,
+    entry: state_mod.InstanceEntry,
+    manager_snapshot: ?Snapshot,
+) ?Snapshot {
+    if (!isImportedStandalone(allocator, paths, component, name, entry)) return null;
+
+    const port = readPortFromConfig(allocator, paths, component, name, "gateway.port") orelse return null;
+    if (port == 0) return null;
+
+    const health = health_mod.check(allocator, "127.0.0.1", port, "/health");
+    const status = standaloneStatus(manager_snapshot, health.ok);
+    var snapshot = manager_snapshot orelse Snapshot{ .status = status };
+    snapshot.status = status;
+    snapshot.port = port;
+    if (status == .stopped) {
+        snapshot.pid = null;
+        snapshot.uptime_seconds = null;
+    }
+    return snapshot;
+}
+
+pub fn resolve(
+    allocator: std.mem.Allocator,
+    paths: paths_mod.Paths,
+    manager: *manager_mod.Manager,
+    component: []const u8,
+    name: []const u8,
+    entry: state_mod.InstanceEntry,
+) Snapshot {
+    const manager_snapshot = if (manager.getStatus(component, name)) |status| snapshotFromManager(status) else null;
+    if (deriveImportedStandaloneSnapshot(allocator, paths, component, name, entry, manager_snapshot)) |snapshot| return snapshot;
+    return manager_snapshot orelse .{ .status = .stopped };
+}

--- a/src/api/instances.zig
+++ b/src/api/instances.zig
@@ -15,6 +15,7 @@ const managed_cli = @import("managed_cli.zig");
 const nullclaw_web_channel = @import("../core/nullclaw_web_channel.zig");
 const query_api = @import("query.zig");
 const test_helpers = @import("../test_helpers.zig");
+const instance_runtime = @import("instance_runtime.zig");
 
 const ApiResponse = helpers.ApiResponse;
 const appendEscaped = helpers.appendEscaped;
@@ -27,101 +28,6 @@ const default_tracker_prompt_template =
     "Task {{task.id}}: {{task.title}}\n\n{{task.description}}\n\nMetadata:\n{{task.metadata}}";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/// Read a port value from an instance's config.json using a dot-separated key
-/// (e.g. "gateway.port" → config["gateway"]["port"]).
-fn readPortFromConfig(allocator: std.mem.Allocator, paths: paths_mod.Paths, component: []const u8, name: []const u8, dot_key: []const u8) ?u16 {
-    const config_path = paths.instanceConfig(allocator, component, name) catch return null;
-    defer allocator.free(config_path);
-
-    const file = std_compat.fs.openFileAbsolute(config_path, .{}) catch return null;
-    defer file.close();
-    const contents = file.readToEndAlloc(allocator, 4 * 1024 * 1024) catch return null;
-    defer allocator.free(contents);
-
-    // Parse as generic JSON and walk the dot-path
-    const parsed = std.json.parseFromSlice(std.json.Value, allocator, contents, .{
-        .allocate = .alloc_always,
-    }) catch return null;
-    defer parsed.deinit();
-
-    var current = parsed.value;
-    var it = std.mem.splitScalar(u8, dot_key, '.');
-    while (it.next()) |segment| {
-        switch (current) {
-            .object => |obj| {
-                current = obj.get(segment) orelse return null;
-            },
-            else => return null,
-        }
-    }
-
-    switch (current) {
-        .integer => |v| return if (v >= 0 and v <= 65535) @intCast(v) else null,
-        else => return null,
-    }
-}
-
-const InstanceSnapshot = struct {
-    status: manager_mod.Status,
-    pid: ?std.process.Child.Id = null,
-    uptime_seconds: ?u64 = null,
-    restart_count: u32 = 0,
-    port: u16 = 0,
-};
-
-fn deriveStandaloneSnapshot(
-    allocator: std.mem.Allocator,
-    paths: paths_mod.Paths,
-    component: []const u8,
-    name: []const u8,
-    entry: state_mod.InstanceEntry,
-) ?InstanceSnapshot {
-    if (!std.mem.eql(u8, component, "nullclaw")) return null;
-
-    const inst_dir = paths.instanceDir(allocator, component, name) catch return null;
-    defer allocator.free(inst_dir);
-    const real_dir = std_compat.fs.realpathAlloc(allocator, inst_dir) catch return null;
-    defer allocator.free(real_dir);
-
-    const home = std_compat.process.getEnvVarOwned(allocator, "HOME") catch return null;
-    defer allocator.free(home);
-    const standalone_root = std.fmt.allocPrint(allocator, "{s}/.{s}", .{ home, component }) catch return null;
-    defer allocator.free(standalone_root);
-
-    if (!std.mem.eql(u8, real_dir, standalone_root)) return null;
-    if (!std.mem.eql(u8, entry.launch_mode, "gateway")) return null;
-
-    const port = readPortFromConfig(allocator, paths, component, name, "gateway.port") orelse 0;
-    if (port == 0) return null;
-
-    const health = @import("../supervisor/health.zig").check(allocator, "127.0.0.1", port, "/health");
-    return .{
-        .status = if (health.ok) .running else .stopped,
-        .port = port,
-    };
-}
-
-fn resolveInstanceSnapshot(
-    allocator: std.mem.Allocator,
-    paths: paths_mod.Paths,
-    manager: *manager_mod.Manager,
-    component: []const u8,
-    name: []const u8,
-    entry: state_mod.InstanceEntry,
-) InstanceSnapshot {
-    if (manager.getStatus(component, name)) |st| {
-        return .{
-            .status = st.status,
-            .pid = st.pid,
-            .uptime_seconds = st.uptime_seconds,
-            .restart_count = st.restart_count,
-            .port = st.port,
-        };
-    }
-    if (deriveStandaloneSnapshot(allocator, paths, component, name, entry)) |snapshot| return snapshot;
-    return .{ .status = .stopped };
-}
 
 const FetchedJsonValue = struct {
     bytes: []u8,
@@ -1834,7 +1740,7 @@ fn pidToU64(pid: std.process.Child.Id) u64 {
     };
 }
 
-fn appendInstanceJson(buf: *std.array_list.Managed(u8), entry: state_mod.InstanceEntry, snapshot: InstanceSnapshot) !void {
+fn appendInstanceJson(buf: *std.array_list.Managed(u8), entry: state_mod.InstanceEntry, snapshot: instance_runtime.Snapshot) !void {
     const status_str = @tagName(snapshot.status);
     try buf.appendSlice("{\"version\":\"");
     try appendEscaped(buf, entry.version);
@@ -1849,28 +1755,28 @@ fn appendInstanceJson(buf: *std.array_list.Managed(u8), entry: state_mod.Instanc
     try buf.append('"');
 
     if (snapshot.pid) |pid| {
-            try buf.appendSlice(",\"pid\":");
-            var num_buf: [20]u8 = undefined;
-            const text = try std.fmt.bufPrint(&num_buf, "{d}", .{pidToU64(pid)});
-            try buf.appendSlice(text);
+        try buf.appendSlice(",\"pid\":");
+        var num_buf: [20]u8 = undefined;
+        const text = try std.fmt.bufPrint(&num_buf, "{d}", .{pidToU64(pid)});
+        try buf.appendSlice(text);
     }
     if (snapshot.uptime_seconds) |uptime| {
-            try buf.appendSlice(",\"uptime_seconds\":");
-            var num_buf: [20]u8 = undefined;
-            const text = try std.fmt.bufPrint(&num_buf, "{d}", .{uptime});
-            try buf.appendSlice(text);
+        try buf.appendSlice(",\"uptime_seconds\":");
+        var num_buf: [20]u8 = undefined;
+        const text = try std.fmt.bufPrint(&num_buf, "{d}", .{uptime});
+        try buf.appendSlice(text);
     }
     if (snapshot.restart_count > 0) {
-            try buf.appendSlice(",\"restart_count\":");
-            var num_buf: [20]u8 = undefined;
-            const text = try std.fmt.bufPrint(&num_buf, "{d}", .{snapshot.restart_count});
-            try buf.appendSlice(text);
+        try buf.appendSlice(",\"restart_count\":");
+        var num_buf: [20]u8 = undefined;
+        const text = try std.fmt.bufPrint(&num_buf, "{d}", .{snapshot.restart_count});
+        try buf.appendSlice(text);
     }
     if (snapshot.port > 0) {
-            try buf.appendSlice(",\"port\":");
-            var num_buf: [10]u8 = undefined;
-            const text = try std.fmt.bufPrint(&num_buf, "{d}", .{snapshot.port});
-            try buf.appendSlice(text);
+        try buf.appendSlice(",\"port\":");
+        var num_buf: [10]u8 = undefined;
+        const text = try std.fmt.bufPrint(&num_buf, "{d}", .{snapshot.port});
+        try buf.appendSlice(text);
     }
 
     try buf.append('}');
@@ -1910,7 +1816,7 @@ fn buildListJson(buf: *std.array_list.Managed(u8), s: *state_mod.State, manager:
             if (!first_inst) try buf.append(',');
             first_inst = false;
 
-            const snapshot = resolveInstanceSnapshot(buf.allocator, paths, manager, comp_entry.key_ptr.*, inst_entry.key_ptr.*, inst_entry.value_ptr.*);
+            const snapshot = instance_runtime.resolve(buf.allocator, paths, manager, comp_entry.key_ptr.*, inst_entry.key_ptr.*, inst_entry.value_ptr.*);
 
             try buf.append('"');
             try appendEscaped(buf, inst_entry.key_ptr.*);
@@ -1928,7 +1834,7 @@ fn buildListJson(buf: *std.array_list.Managed(u8), s: *state_mod.State, manager:
 pub fn handleGet(allocator: std.mem.Allocator, s: *state_mod.State, manager: *manager_mod.Manager, paths: paths_mod.Paths, component: []const u8, name: []const u8) ApiResponse {
     const entry = s.getInstance(component, name) orelse return notFound();
 
-    const snapshot = resolveInstanceSnapshot(allocator, paths, manager, component, name, entry);
+    const snapshot = instance_runtime.resolve(allocator, paths, manager, component, name, entry);
 
     var buf = std.array_list.Managed(u8).init(allocator);
     appendInstanceJson(&buf, entry, snapshot) catch return .{
@@ -2004,7 +1910,7 @@ pub fn handleStart(allocator: std.mem.Allocator, s: *state_mod.State, manager: *
 
     // Try to read actual port from instance config.json using port_from_config key
     if (port_from_config.len > 0) {
-        if (readPortFromConfig(allocator, paths, component, name, port_from_config)) |config_port| {
+        if (instance_runtime.readPortFromConfig(allocator, paths, component, name, port_from_config)) |config_port| {
             port = config_port;
         }
     }
@@ -2144,12 +2050,7 @@ pub fn handleProviderHealth(allocator: std.mem.Allocator, s: *state_mod.State, m
         configured = true;
     }
 
-    const running = blk: {
-        if (manager.getStatus(component, name)) |st| {
-            break :blk st.status == .running;
-        }
-        break :blk false;
-    };
+    const running = instance_runtime.resolve(allocator, paths, manager, component, name, entry).status == .running;
 
     var status: []const u8 = "unknown";
     var reason: []const u8 = "not_probed";

--- a/src/api/instances.zig
+++ b/src/api/instances.zig
@@ -61,6 +61,67 @@ fn readPortFromConfig(allocator: std.mem.Allocator, paths: paths_mod.Paths, comp
     }
 }
 
+const InstanceSnapshot = struct {
+    status: manager_mod.Status,
+    pid: ?std.process.Child.Id = null,
+    uptime_seconds: ?u64 = null,
+    restart_count: u32 = 0,
+    port: u16 = 0,
+};
+
+fn deriveStandaloneSnapshot(
+    allocator: std.mem.Allocator,
+    paths: paths_mod.Paths,
+    component: []const u8,
+    name: []const u8,
+    entry: state_mod.InstanceEntry,
+) ?InstanceSnapshot {
+    if (!std.mem.eql(u8, component, "nullclaw")) return null;
+
+    const inst_dir = paths.instanceDir(allocator, component, name) catch return null;
+    defer allocator.free(inst_dir);
+    const real_dir = std_compat.fs.realpathAlloc(allocator, inst_dir) catch return null;
+    defer allocator.free(real_dir);
+
+    const home = std_compat.process.getEnvVarOwned(allocator, "HOME") catch return null;
+    defer allocator.free(home);
+    const standalone_root = std.fmt.allocPrint(allocator, "{s}/.{s}", .{ home, component }) catch return null;
+    defer allocator.free(standalone_root);
+
+    if (!std.mem.eql(u8, real_dir, standalone_root)) return null;
+    if (!std.mem.eql(u8, entry.launch_mode, "gateway")) return null;
+
+    const port = readPortFromConfig(allocator, paths, component, name, "gateway.port") orelse 0;
+    if (port == 0) return null;
+
+    const health = @import("../supervisor/health.zig").check(allocator, "127.0.0.1", port, "/health");
+    return .{
+        .status = if (health.ok) .running else .stopped,
+        .port = port,
+    };
+}
+
+fn resolveInstanceSnapshot(
+    allocator: std.mem.Allocator,
+    paths: paths_mod.Paths,
+    manager: *manager_mod.Manager,
+    component: []const u8,
+    name: []const u8,
+    entry: state_mod.InstanceEntry,
+) InstanceSnapshot {
+    if (manager.getStatus(component, name)) |st| {
+        return .{
+            .status = st.status,
+            .pid = st.pid,
+            .uptime_seconds = st.uptime_seconds,
+            .restart_count = st.restart_count,
+            .port = st.port,
+        };
+    }
+    if (deriveStandaloneSnapshot(allocator, paths, component, name, entry)) |snapshot| return snapshot;
+    return .{ .status = .stopped };
+}
+
 const FetchedJsonValue = struct {
     bytes: []u8,
     parsed: std.json.Parsed(std.json.Value),
@@ -1772,8 +1833,8 @@ fn pidToU64(pid: std.process.Child.Id) u64 {
     };
 }
 
-fn appendInstanceJson(buf: *std.array_list.Managed(u8), entry: state_mod.InstanceEntry, runtime_status: ?manager_mod.InstanceStatus) !void {
-    const status_str = if (runtime_status) |status| @tagName(status.status) else "stopped";
+fn appendInstanceJson(buf: *std.array_list.Managed(u8), entry: state_mod.InstanceEntry, snapshot: InstanceSnapshot) !void {
+    const status_str = @tagName(snapshot.status);
     try buf.appendSlice("{\"version\":\"");
     try appendEscaped(buf, entry.version);
     try buf.appendSlice("\",\"auto_start\":");
@@ -1786,31 +1847,29 @@ fn appendInstanceJson(buf: *std.array_list.Managed(u8), entry: state_mod.Instanc
     try buf.appendSlice(status_str);
     try buf.append('"');
 
-    if (runtime_status) |status| {
-        if (status.pid) |pid| {
+    if (snapshot.pid) |pid| {
             try buf.appendSlice(",\"pid\":");
             var num_buf: [20]u8 = undefined;
             const text = try std.fmt.bufPrint(&num_buf, "{d}", .{pidToU64(pid)});
             try buf.appendSlice(text);
-        }
-        if (status.uptime_seconds) |uptime| {
+    }
+    if (snapshot.uptime_seconds) |uptime| {
             try buf.appendSlice(",\"uptime_seconds\":");
             var num_buf: [20]u8 = undefined;
             const text = try std.fmt.bufPrint(&num_buf, "{d}", .{uptime});
             try buf.appendSlice(text);
-        }
-        if (status.restart_count > 0) {
+    }
+    if (snapshot.restart_count > 0) {
             try buf.appendSlice(",\"restart_count\":");
             var num_buf: [20]u8 = undefined;
-            const text = try std.fmt.bufPrint(&num_buf, "{d}", .{status.restart_count});
+            const text = try std.fmt.bufPrint(&num_buf, "{d}", .{snapshot.restart_count});
             try buf.appendSlice(text);
-        }
-        if (status.port > 0) {
+    }
+    if (snapshot.port > 0) {
             try buf.appendSlice(",\"port\":");
             var num_buf: [10]u8 = undefined;
-            const text = try std.fmt.bufPrint(&num_buf, "{d}", .{status.port});
+            const text = try std.fmt.bufPrint(&num_buf, "{d}", .{snapshot.port});
             try buf.appendSlice(text);
-        }
     }
 
     try buf.append('}');
@@ -1819,10 +1878,10 @@ fn appendInstanceJson(buf: *std.array_list.Managed(u8), entry: state_mod.Instanc
 // ─── Handlers ────────────────────────────────────────────────────────────────
 
 /// GET /api/instances — list all instances grouped by component.
-pub fn handleList(allocator: std.mem.Allocator, s: *state_mod.State, manager: *manager_mod.Manager) ApiResponse {
+pub fn handleList(allocator: std.mem.Allocator, s: *state_mod.State, manager: *manager_mod.Manager, paths: paths_mod.Paths) ApiResponse {
     var buf = std.array_list.Managed(u8).init(allocator);
 
-    buildListJson(&buf, s, manager) catch return .{
+    buildListJson(&buf, s, manager, paths) catch return .{
         .status = "500 Internal Server Error",
         .content_type = "application/json",
         .body = "{\"error\":\"internal error\"}",
@@ -1831,7 +1890,7 @@ pub fn handleList(allocator: std.mem.Allocator, s: *state_mod.State, manager: *m
     return jsonOk(buf.items);
 }
 
-fn buildListJson(buf: *std.array_list.Managed(u8), s: *state_mod.State, manager: *manager_mod.Manager) !void {
+fn buildListJson(buf: *std.array_list.Managed(u8), s: *state_mod.State, manager: *manager_mod.Manager, paths: paths_mod.Paths) !void {
     try buf.appendSlice("{\"instances\":{");
 
     var comp_it = s.instances.iterator();
@@ -1850,12 +1909,12 @@ fn buildListJson(buf: *std.array_list.Managed(u8), s: *state_mod.State, manager:
             if (!first_inst) try buf.append(',');
             first_inst = false;
 
-            const runtime_status = manager.getStatus(comp_entry.key_ptr.*, inst_entry.key_ptr.*);
+            const snapshot = resolveInstanceSnapshot(buf.allocator, paths, manager, comp_entry.key_ptr.*, inst_entry.key_ptr.*, inst_entry.value_ptr.*);
 
             try buf.append('"');
             try appendEscaped(buf, inst_entry.key_ptr.*);
             try buf.appendSlice("\":");
-            try appendInstanceJson(buf, inst_entry.value_ptr.*, runtime_status);
+            try appendInstanceJson(buf, inst_entry.value_ptr.*, snapshot);
         }
 
         try buf.append('}');
@@ -1865,13 +1924,13 @@ fn buildListJson(buf: *std.array_list.Managed(u8), s: *state_mod.State, manager:
 }
 
 /// GET /api/instances/{component}/{name} — detail for one instance.
-pub fn handleGet(allocator: std.mem.Allocator, s: *state_mod.State, manager: *manager_mod.Manager, component: []const u8, name: []const u8) ApiResponse {
+pub fn handleGet(allocator: std.mem.Allocator, s: *state_mod.State, manager: *manager_mod.Manager, paths: paths_mod.Paths, component: []const u8, name: []const u8) ApiResponse {
     const entry = s.getInstance(component, name) orelse return notFound();
 
-    const runtime_status = manager.getStatus(component, name);
+    const snapshot = resolveInstanceSnapshot(allocator, paths, manager, component, name, entry);
 
     var buf = std.array_list.Managed(u8).init(allocator);
-    appendInstanceJson(&buf, entry, runtime_status) catch return .{
+    appendInstanceJson(&buf, entry, snapshot) catch return .{
         .status = "500 Internal Server Error",
         .content_type = "application/json",
         .body = "{\"error\":\"internal error\"}",
@@ -3651,7 +3710,7 @@ pub fn dispatch(
 ) ?ApiResponse {
     // Exact match for the collection endpoint.
     if (std.mem.eql(u8, stripQuery(target), "/api/instances")) {
-        if (std.mem.eql(u8, method, "GET")) return handleList(allocator, s, manager);
+        if (std.mem.eql(u8, method, "GET")) return handleList(allocator, s, manager, paths);
         return methodNotAllowed();
     }
 
@@ -3841,7 +3900,7 @@ pub fn dispatch(
     }
 
     // No action — CRUD on the instance itself.
-    if (std.mem.eql(u8, method, "GET")) return handleGet(allocator, s, manager, parsed.component, parsed.name);
+    if (std.mem.eql(u8, method, "GET")) return handleGet(allocator, s, manager, paths, parsed.component, parsed.name);
     if (std.mem.eql(u8, method, "DELETE")) return handleDelete(allocator, s, manager, paths, parsed.component, parsed.name);
     if (std.mem.eql(u8, method, "PATCH")) return handlePatch(s, parsed.component, parsed.name, body);
 

--- a/src/api/status.zig
+++ b/src/api/status.zig
@@ -1,9 +1,11 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const std_compat = @import("compat");
 const state_mod = @import("../core/state.zig");
 const platform = @import("../core/platform.zig");
 const manager_mod = @import("../supervisor/manager.zig");
 const paths_mod = @import("../core/paths.zig");
+const health_mod = @import("../supervisor/health.zig");
 const helpers = @import("helpers.zig");
 const access = @import("../access.zig");
 const version = @import("../version.zig");
@@ -139,13 +141,103 @@ fn appendInstanceJson(buf: *std.array_list.Managed(u8), entry: state_mod.Instanc
     try buf.append('}');
 }
 
+fn readPortFromConfig(allocator: std.mem.Allocator, paths: paths_mod.Paths, component: []const u8, name: []const u8, dot_key: []const u8) ?u16 {
+    const config_path = paths.instanceConfig(allocator, component, name) catch return null;
+    defer allocator.free(config_path);
+
+    const file = std_compat.fs.openFileAbsolute(config_path, .{}) catch return null;
+    defer file.close();
+    const contents = file.readToEndAlloc(allocator, 4 * 1024 * 1024) catch return null;
+    defer allocator.free(contents);
+
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, contents, .{
+        .allocate = .alloc_always,
+    }) catch return null;
+    defer parsed.deinit();
+
+    var current = parsed.value;
+    var it = std.mem.splitScalar(u8, dot_key, '.');
+    while (it.next()) |segment| {
+        switch (current) {
+            .object => |obj| current = obj.get(segment) orelse return null,
+            else => return null,
+        }
+    }
+
+    return switch (current) {
+        .integer => |v| if (v >= 0 and v <= 65535) @intCast(v) else null,
+        else => null,
+    };
+}
+
+const InstanceSnapshot = struct {
+    status: manager_mod.Status,
+    pid: ?std.process.Child.Id = null,
+    uptime_seconds: ?u64 = null,
+    restart_count: u32 = 0,
+    port: u16 = 0,
+};
+
+fn deriveStandaloneSnapshot(
+    allocator: std.mem.Allocator,
+    paths: paths_mod.Paths,
+    component: []const u8,
+    name: []const u8,
+    entry: state_mod.InstanceEntry,
+) ?InstanceSnapshot {
+    if (!std.mem.eql(u8, component, "nullclaw")) return null;
+
+    const inst_dir = paths.instanceDir(allocator, component, name) catch return null;
+    defer allocator.free(inst_dir);
+    const real_dir = std_compat.fs.realpathAlloc(allocator, inst_dir) catch return null;
+    defer allocator.free(real_dir);
+
+    const home = std_compat.process.getEnvVarOwned(allocator, "HOME") catch return null;
+    defer allocator.free(home);
+    const standalone_root = std.fmt.allocPrint(allocator, "{s}/.{s}", .{ home, component }) catch return null;
+    defer allocator.free(standalone_root);
+
+    if (!std.mem.eql(u8, real_dir, standalone_root)) return null;
+    if (!std.mem.eql(u8, entry.launch_mode, "gateway")) return null;
+
+    const port = readPortFromConfig(allocator, paths, component, name, "gateway.port") orelse 0;
+    if (port == 0) return null;
+
+    const health = health_mod.check(allocator, "127.0.0.1", port, "/health");
+    return .{
+        .status = if (health.ok) .running else .stopped,
+        .port = port,
+    };
+}
+
+fn resolveInstanceSnapshot(
+    allocator: std.mem.Allocator,
+    paths: paths_mod.Paths,
+    manager: *manager_mod.Manager,
+    component: []const u8,
+    name: []const u8,
+    entry: state_mod.InstanceEntry,
+) InstanceSnapshot {
+    if (manager.getStatus(component, name)) |st| {
+        return .{
+            .status = st.status,
+            .pid = st.pid,
+            .uptime_seconds = st.uptime_seconds,
+            .restart_count = st.restart_count,
+            .port = st.port,
+        };
+    }
+    if (deriveStandaloneSnapshot(allocator, paths, component, name, entry)) |snapshot| return snapshot;
+    return .{ .status = .stopped };
+}
+
 // ─── Handlers ────────────────────────────────────────────────────────────────
 
 /// GET /api/status — aggregated dashboard data.
-pub fn handleStatus(allocator: std.mem.Allocator, s: *state_mod.State, manager: *manager_mod.Manager, uptime_seconds: u64, host: []const u8, port: u16, access_options: access.Options) ApiResponse {
+pub fn handleStatus(allocator: std.mem.Allocator, s: *state_mod.State, manager: *manager_mod.Manager, paths: paths_mod.Paths, uptime_seconds: u64, host: []const u8, port: u16, access_options: access.Options) ApiResponse {
     var buf = std.array_list.Managed(u8).init(allocator);
 
-    buildStatusJson(&buf, s, manager, uptime_seconds, host, port, access_options) catch return .{
+    buildStatusJson(&buf, s, manager, paths, uptime_seconds, host, port, access_options) catch return .{
         .status = "500 Internal Server Error",
         .content_type = "application/json",
         .body = "{\"error\":\"internal error\"}",
@@ -154,7 +246,7 @@ pub fn handleStatus(allocator: std.mem.Allocator, s: *state_mod.State, manager: 
     return .{ .status = "200 OK", .content_type = "application/json", .body = buf.items };
 }
 
-fn buildStatusJson(buf: *std.array_list.Managed(u8), s: *state_mod.State, manager: *manager_mod.Manager, uptime_seconds: u64, host: []const u8, port: u16, access_options: access.Options) !void {
+fn buildStatusJson(buf: *std.array_list.Managed(u8), s: *state_mod.State, manager: *manager_mod.Manager, paths: paths_mod.Paths, uptime_seconds: u64, host: []const u8, port: u16, access_options: access.Options) !void {
     var urls = try access.buildAccessUrlsWithOptions(buf.allocator, host, port, access_options);
     defer urls.deinit(buf.allocator);
     var component_rollups = std.StringHashMap(ComponentRollup).init(buf.allocator);
@@ -171,8 +263,8 @@ fn buildStatusJson(buf: *std.array_list.Managed(u8), s: *state_mod.State, manage
         var rollup = ComponentRollup{};
         var inst_it = comp_entry.value_ptr.iterator();
         while (inst_it.next()) |inst_entry| {
-            const mgr_status = manager.getStatus(comp_entry.key_ptr.*, inst_entry.key_ptr.*);
-            const runtime_status = if (mgr_status) |st| st.status else manager_mod.Status.stopped;
+            const snapshot = resolveInstanceSnapshot(buf.allocator, paths, manager, comp_entry.key_ptr.*, inst_entry.key_ptr.*, inst_entry.value_ptr.*);
+            const runtime_status = snapshot.status;
             rollup.total += 1;
             if (inst_entry.value_ptr.auto_start) rollup.auto_start += 1;
             observeStatus(&rollup, runtime_status);
@@ -257,12 +349,12 @@ fn buildStatusJson(buf: *std.array_list.Managed(u8), s: *state_mod.State, manage
 
             const comp_name = comp_entry.key_ptr.*;
             const inst_name = inst_entry.key_ptr.*;
-            const mgr_status = manager.getStatus(comp_name, inst_name);
-            const status_str = if (mgr_status) |st| @tagName(st.status) else "stopped";
-            const pid = if (mgr_status) |st| st.pid else null;
-            const instance_uptime = if (mgr_status) |st| st.uptime_seconds else null;
-            const restart_count: u32 = if (mgr_status) |st| st.restart_count else 0;
-            const instance_port: u16 = if (mgr_status) |st| st.port else 0;
+            const snapshot = resolveInstanceSnapshot(buf.allocator, paths, manager, comp_name, inst_name, inst_entry.value_ptr.*);
+            const status_str = @tagName(snapshot.status);
+            const pid = snapshot.pid;
+            const instance_uptime = snapshot.uptime_seconds;
+            const restart_count: u32 = snapshot.restart_count;
+            const instance_port: u16 = snapshot.port;
 
             try buf.append('"');
             try appendEscaped(buf, inst_name);
@@ -289,7 +381,7 @@ test "handleStatus returns valid JSON with hub version" {
     var mgr = manager_mod.Manager.init(allocator, p);
     defer mgr.deinit();
 
-    const resp = handleStatus(allocator, &s, &mgr, 3600, access.default_bind_host, access.default_port, .{});
+    const resp = handleStatus(allocator, &s, &mgr, p, 3600, access.default_bind_host, access.default_port, .{});
     defer allocator.free(resp.body);
 
     try std.testing.expectEqualStrings("200 OK", resp.status);
@@ -356,7 +448,7 @@ test "handleStatus includes instances" {
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "2026.3.1", .auto_start = true });
 
-    const resp = handleStatus(allocator, &s, &mgr, 0, access.default_bind_host, access.default_port, .{});
+    const resp = handleStatus(allocator, &s, &mgr, p, 0, access.default_bind_host, access.default_port, .{});
     defer allocator.free(resp.body);
 
     try std.testing.expectEqualStrings("200 OK", resp.status);
@@ -427,7 +519,7 @@ test "handleStatus overall_status becomes error when a component has failed inst
         .status = .failed,
     });
 
-    const resp = handleStatus(allocator, &s, &mgr, 0, access.default_bind_host, access.default_port, .{});
+    const resp = handleStatus(allocator, &s, &mgr, p, 0, access.default_bind_host, access.default_port, .{});
     defer allocator.free(resp.body);
 
     try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"overall_status\":\"error\"") != null);
@@ -447,7 +539,7 @@ test "handleStatus includes launch_mode" {
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0", .launch_mode = "agent" });
 
-    const resp = handleStatus(allocator, &s, &mgr, 0, access.default_bind_host, access.default_port, .{});
+    const resp = handleStatus(allocator, &s, &mgr, p, 0, access.default_bind_host, access.default_port, .{});
     defer allocator.free(resp.body);
 
     try std.testing.expectEqualStrings("200 OK", resp.status);
@@ -465,7 +557,7 @@ test "handleStatus includes verbose flag" {
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0", .verbose = true });
 
-    const resp = handleStatus(allocator, &s, &mgr, 0, access.default_bind_host, access.default_port, .{});
+    const resp = handleStatus(allocator, &s, &mgr, p, 0, access.default_bind_host, access.default_port, .{});
     defer allocator.free(resp.body);
 
     try std.testing.expectEqualStrings("200 OK", resp.status);
@@ -481,7 +573,7 @@ test "handleStatus with empty state returns empty instances" {
     var mgr = manager_mod.Manager.init(allocator, p);
     defer mgr.deinit();
 
-    const resp = handleStatus(allocator, &s, &mgr, 42, access.default_bind_host, access.default_port, .{});
+    const resp = handleStatus(allocator, &s, &mgr, p, 42, access.default_bind_host, access.default_port, .{});
     defer allocator.free(resp.body);
 
     try std.testing.expectEqualStrings("200 OK", resp.status);

--- a/src/api/status.zig
+++ b/src/api/status.zig
@@ -1,15 +1,14 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const std_compat = @import("compat");
 const state_mod = @import("../core/state.zig");
 const platform = @import("../core/platform.zig");
 const manager_mod = @import("../supervisor/manager.zig");
 const paths_mod = @import("../core/paths.zig");
-const health_mod = @import("../supervisor/health.zig");
 const helpers = @import("helpers.zig");
 const access = @import("../access.zig");
 const version = @import("../version.zig");
 const test_helpers = @import("../test_helpers.zig");
+const instance_runtime = @import("instance_runtime.zig");
 
 const ApiResponse = helpers.ApiResponse;
 const appendEscaped = helpers.appendEscaped;
@@ -142,96 +141,6 @@ fn appendInstanceJson(buf: *std.array_list.Managed(u8), entry: state_mod.Instanc
     try buf.append('}');
 }
 
-fn readPortFromConfig(allocator: std.mem.Allocator, paths: paths_mod.Paths, component: []const u8, name: []const u8, dot_key: []const u8) ?u16 {
-    const config_path = paths.instanceConfig(allocator, component, name) catch return null;
-    defer allocator.free(config_path);
-
-    const file = std_compat.fs.openFileAbsolute(config_path, .{}) catch return null;
-    defer file.close();
-    const contents = file.readToEndAlloc(allocator, 4 * 1024 * 1024) catch return null;
-    defer allocator.free(contents);
-
-    const parsed = std.json.parseFromSlice(std.json.Value, allocator, contents, .{
-        .allocate = .alloc_always,
-    }) catch return null;
-    defer parsed.deinit();
-
-    var current = parsed.value;
-    var it = std.mem.splitScalar(u8, dot_key, '.');
-    while (it.next()) |segment| {
-        switch (current) {
-            .object => |obj| current = obj.get(segment) orelse return null,
-            else => return null,
-        }
-    }
-
-    return switch (current) {
-        .integer => |v| if (v >= 0 and v <= 65535) @intCast(v) else null,
-        else => null,
-    };
-}
-
-const InstanceSnapshot = struct {
-    status: manager_mod.Status,
-    pid: ?std.process.Child.Id = null,
-    uptime_seconds: ?u64 = null,
-    restart_count: u32 = 0,
-    port: u16 = 0,
-};
-
-fn deriveStandaloneSnapshot(
-    allocator: std.mem.Allocator,
-    paths: paths_mod.Paths,
-    component: []const u8,
-    name: []const u8,
-    entry: state_mod.InstanceEntry,
-) ?InstanceSnapshot {
-    if (!std.mem.eql(u8, component, "nullclaw")) return null;
-
-    const inst_dir = paths.instanceDir(allocator, component, name) catch return null;
-    defer allocator.free(inst_dir);
-    const real_dir = std_compat.fs.realpathAlloc(allocator, inst_dir) catch return null;
-    defer allocator.free(real_dir);
-
-    const home = std_compat.process.getEnvVarOwned(allocator, "HOME") catch return null;
-    defer allocator.free(home);
-    const standalone_root = std.fmt.allocPrint(allocator, "{s}/.{s}", .{ home, component }) catch return null;
-    defer allocator.free(standalone_root);
-
-    if (!std.mem.eql(u8, real_dir, standalone_root)) return null;
-    if (!std.mem.eql(u8, entry.launch_mode, "gateway")) return null;
-
-    const port = readPortFromConfig(allocator, paths, component, name, "gateway.port") orelse 0;
-    if (port == 0) return null;
-
-    const health = health_mod.check(allocator, "127.0.0.1", port, "/health");
-    return .{
-        .status = if (health.ok) .running else .stopped,
-        .port = port,
-    };
-}
-
-fn resolveInstanceSnapshot(
-    allocator: std.mem.Allocator,
-    paths: paths_mod.Paths,
-    manager: *manager_mod.Manager,
-    component: []const u8,
-    name: []const u8,
-    entry: state_mod.InstanceEntry,
-) InstanceSnapshot {
-    if (manager.getStatus(component, name)) |st| {
-        return .{
-            .status = st.status,
-            .pid = st.pid,
-            .uptime_seconds = st.uptime_seconds,
-            .restart_count = st.restart_count,
-            .port = st.port,
-        };
-    }
-    if (deriveStandaloneSnapshot(allocator, paths, component, name, entry)) |snapshot| return snapshot;
-    return .{ .status = .stopped };
-}
-
 // ─── Handlers ────────────────────────────────────────────────────────────────
 
 /// GET /api/status — aggregated dashboard data.
@@ -264,7 +173,7 @@ fn buildStatusJson(buf: *std.array_list.Managed(u8), s: *state_mod.State, manage
         var rollup = ComponentRollup{};
         var inst_it = comp_entry.value_ptr.iterator();
         while (inst_it.next()) |inst_entry| {
-            const snapshot = resolveInstanceSnapshot(buf.allocator, paths, manager, comp_entry.key_ptr.*, inst_entry.key_ptr.*, inst_entry.value_ptr.*);
+            const snapshot = instance_runtime.resolve(buf.allocator, paths, manager, comp_entry.key_ptr.*, inst_entry.key_ptr.*, inst_entry.value_ptr.*);
             const runtime_status = snapshot.status;
             rollup.total += 1;
             if (inst_entry.value_ptr.auto_start) rollup.auto_start += 1;
@@ -350,7 +259,7 @@ fn buildStatusJson(buf: *std.array_list.Managed(u8), s: *state_mod.State, manage
 
             const comp_name = comp_entry.key_ptr.*;
             const inst_name = inst_entry.key_ptr.*;
-            const snapshot = resolveInstanceSnapshot(buf.allocator, paths, manager, comp_name, inst_name, inst_entry.value_ptr.*);
+            const snapshot = instance_runtime.resolve(buf.allocator, paths, manager, comp_name, inst_name, inst_entry.value_ptr.*);
             const status_str = @tagName(snapshot.status);
             const pid = snapshot.pid;
             const instance_uptime = snapshot.uptime_seconds;
@@ -384,7 +293,7 @@ test "handleStatus returns valid JSON with hub version" {
     var mgr = manager_mod.Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
-    const resp = handleStatus(allocator, &s, &mgr, p, 3600, access.default_bind_host, access.default_port, .{});
+    const resp = handleStatus(allocator, &s, &mgr, fixture.paths, 3600, access.default_bind_host, access.default_port, .{});
     defer allocator.free(resp.body);
 
     try std.testing.expectEqualStrings("200 OK", resp.status);
@@ -453,7 +362,7 @@ test "handleStatus includes instances" {
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "2026.3.1", .auto_start = true });
 
-    const resp = handleStatus(allocator, &s, &mgr, p, 0, access.default_bind_host, access.default_port, .{});
+    const resp = handleStatus(allocator, &s, &mgr, fixture.paths, 0, access.default_bind_host, access.default_port, .{});
     defer allocator.free(resp.body);
 
     try std.testing.expectEqualStrings("200 OK", resp.status);
@@ -526,7 +435,7 @@ test "handleStatus overall_status becomes error when a component has failed inst
         .status = .failed,
     });
 
-    const resp = handleStatus(allocator, &s, &mgr, p, 0, access.default_bind_host, access.default_port, .{});
+    const resp = handleStatus(allocator, &s, &mgr, fixture.paths, 0, access.default_bind_host, access.default_port, .{});
     defer allocator.free(resp.body);
 
     try std.testing.expect(std.mem.indexOf(u8, resp.body, "\"overall_status\":\"error\"") != null);
@@ -548,7 +457,7 @@ test "handleStatus includes launch_mode" {
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0", .launch_mode = "agent" });
 
-    const resp = handleStatus(allocator, &s, &mgr, p, 0, access.default_bind_host, access.default_port, .{});
+    const resp = handleStatus(allocator, &s, &mgr, fixture.paths, 0, access.default_bind_host, access.default_port, .{});
     defer allocator.free(resp.body);
 
     try std.testing.expectEqualStrings("200 OK", resp.status);
@@ -568,7 +477,7 @@ test "handleStatus includes verbose flag" {
 
     try s.addInstance("nullclaw", "my-agent", .{ .version = "1.0.0", .verbose = true });
 
-    const resp = handleStatus(allocator, &s, &mgr, p, 0, access.default_bind_host, access.default_port, .{});
+    const resp = handleStatus(allocator, &s, &mgr, fixture.paths, 0, access.default_bind_host, access.default_port, .{});
     defer allocator.free(resp.body);
 
     try std.testing.expectEqualStrings("200 OK", resp.status);
@@ -586,7 +495,7 @@ test "handleStatus with empty state returns empty instances" {
     var mgr = manager_mod.Manager.init(allocator, fixture.paths);
     defer mgr.deinit();
 
-    const resp = handleStatus(allocator, &s, &mgr, p, 42, access.default_bind_host, access.default_port, .{});
+    const resp = handleStatus(allocator, &s, &mgr, fixture.paths, 42, access.default_bind_host, access.default_port, .{});
     defer allocator.free(resp.body);
 
     try std.testing.expectEqualStrings("200 OK", resp.status);

--- a/src/server.zig
+++ b/src/server.zig
@@ -560,7 +560,7 @@ pub const Server = struct {
             if (std.mem.eql(u8, target, "/api/status")) {
                 const now = std_compat.time.timestamp();
                 const uptime: u64 = @intCast(@max(0, now - self.start_time));
-                const resp = status_api.handleStatus(allocator, self.state, self.manager, uptime, self.host, self.port, self.currentAccessOptions());
+                const resp = status_api.handleStatus(allocator, self.state, self.manager, self.paths, uptime, self.host, self.port, self.currentAccessOptions());
                 return .{ .status = resp.status, .content_type = resp.content_type, .body = resp.body };
             }
             if (meta_api.isRoutesPath(target)) {

--- a/src/supervisor/process.zig
+++ b/src/supervisor/process.zig
@@ -5,34 +5,24 @@ const windows = std.os.windows;
 
 const darwin = if (builtin.os.tag == .macos) struct {
     const extern_structs = struct {
-        pub const ProcBsdInfo = extern struct {
-            proc_pid: u32,
-            proc_ppid: u32,
-            proc_pgid: u32,
-            proc_status: u32,
-            proc_comm: [17]u8,
-            proc_name: [33]u8,
-            proc_nice: i32,
-            proc_flag: u32,
-            proc_uid: u32,
-            proc_ruid: u32,
-            proc_svuid: u32,
-            proc_rgid: u32,
-            proc_svgid: u32,
-            rfu_1: u32,
-            proc_comm2: [17]u8,
-            proc_xstatus: u32,
-            proc_acflag: u32,
-            proc_pctcpu: u32,
-            proc_estcpu: u32,
-            proc_slptime: u32,
-            proc_realtimer: u64,
-            proc_start_tvsec: u64,
-            proc_start_tvusec: u64,
+        pub const ProcBsdShortInfo = extern struct {
+            pbsi_pid: u32,
+            pbsi_ppid: u32,
+            pbsi_pgid: u32,
+            pbsi_status: u32,
+            pbsi_comm: [16]u8,
+            pbsi_flags: u32,
+            pbsi_uid: u32,
+            pbsi_gid: u32,
+            pbsi_ruid: u32,
+            pbsi_rgid: u32,
+            pbsi_svuid: u32,
+            pbsi_svgid: u32,
+            pbsi_rfu: u32,
         };
     };
 
-    const PROC_PIDTBSDINFO: i32 = 3;
+    const PROC_PIDT_SHORTBSDINFO: i32 = 13;
     const SZOMB: u32 = 5;
 
     extern "c" fn proc_pidinfo(pid: i32, flavor: i32, arg: u64, buffer: ?*anyopaque, buffersize: i32) c_int;
@@ -256,16 +246,16 @@ pub fn isAlive(pid: std_compat.process.Child.Id) bool {
 }
 
 fn isDarwinZombie(pid: std_compat.process.Child.Id) bool {
-    var info: darwin.extern_structs.ProcBsdInfo = undefined;
+    var info: darwin.extern_structs.ProcBsdShortInfo = undefined;
     const size = darwin.proc_pidinfo(
         @intCast(pid),
-        darwin.PROC_PIDTBSDINFO,
+        darwin.PROC_PIDT_SHORTBSDINFO,
         0,
         @ptrCast(&info),
-        @sizeOf(darwin.extern_structs.ProcBsdInfo),
+        @sizeOf(darwin.extern_structs.ProcBsdShortInfo),
     );
-    if (size != @sizeOf(darwin.extern_structs.ProcBsdInfo)) return false;
-    return info.proc_status == darwin.SZOMB;
+    if (size != @sizeOf(darwin.extern_structs.ProcBsdShortInfo)) return false;
+    return info.pbsi_status == darwin.SZOMB;
 }
 
 pub fn persistedPidValue(pid: std_compat.process.Child.Id) ?u64 {

--- a/src/supervisor/process.zig
+++ b/src/supervisor/process.zig
@@ -3,6 +3,41 @@ const std_compat = @import("compat");
 const builtin = @import("builtin");
 const windows = std.os.windows;
 
+const darwin = if (builtin.os.tag == .macos) struct {
+    const extern_structs = struct {
+        pub const ProcBsdInfo = extern struct {
+            proc_pid: u32,
+            proc_ppid: u32,
+            proc_pgid: u32,
+            proc_status: u32,
+            proc_comm: [17]u8,
+            proc_name: [33]u8,
+            proc_nice: i32,
+            proc_flag: u32,
+            proc_uid: u32,
+            proc_ruid: u32,
+            proc_svuid: u32,
+            proc_rgid: u32,
+            proc_svgid: u32,
+            rfu_1: u32,
+            proc_comm2: [17]u8,
+            proc_xstatus: u32,
+            proc_acflag: u32,
+            proc_pctcpu: u32,
+            proc_estcpu: u32,
+            proc_slptime: u32,
+            proc_realtimer: u64,
+            proc_start_tvsec: u64,
+            proc_start_tvusec: u64,
+        };
+    };
+
+    const PROC_PIDTBSDINFO: i32 = 3;
+    const SZOMB: u32 = 5;
+
+    extern "c" fn proc_pidinfo(pid: i32, flavor: i32, arg: u64, buffer: ?*anyopaque, buffersize: i32) c_int;
+} else struct {};
+
 const kernel32 = struct {
     extern "kernel32" fn GetProcessId(
         process: windows.HANDLE,
@@ -207,10 +242,30 @@ pub fn isAlive(pid: std_compat.process.Child.Id) bool {
             else => false,
         };
     }
-    return switch (std.posix.errno(std.posix.system.kill(pid, @as(std.posix.SIG, @enumFromInt(0))))) {
+    const alive = switch (std.posix.errno(std.posix.system.kill(pid, @as(std.posix.SIG, @enumFromInt(0))))) {
         .SUCCESS => true,
         else => false,
     };
+    if (!alive) return false;
+
+    if (comptime builtin.os.tag == .macos) {
+        return !isDarwinZombie(pid);
+    }
+
+    return true;
+}
+
+fn isDarwinZombie(pid: std_compat.process.Child.Id) bool {
+    var info: darwin.extern_structs.ProcBsdInfo = undefined;
+    const size = darwin.proc_pidinfo(
+        @intCast(pid),
+        darwin.PROC_PIDTBSDINFO,
+        0,
+        @ptrCast(&info),
+        @sizeOf(darwin.extern_structs.ProcBsdInfo),
+    );
+    if (size != @sizeOf(darwin.extern_structs.ProcBsdInfo)) return false;
+    return info.proc_status == darwin.SZOMB;
 }
 
 pub fn persistedPidValue(pid: std_compat.process.Child.Id) ?u64 {
@@ -362,6 +417,20 @@ test "isAlive returns false for non-existent pid" {
 
     // PID 99999999 is almost certainly not a running process
     try std.testing.expect(!isAlive(99999999));
+}
+
+test "isAlive returns false for zombie process on macOS" {
+    if (comptime builtin.os.tag != .macos) return error.SkipZigTest;
+
+    const result = try spawn(std.testing.allocator, .{
+        .binary = "/bin/sh",
+        .argv = &.{ "-c", "exit 0" },
+    });
+    var child = result.child;
+    defer _ = child.wait() catch {};
+
+    std_compat.thread.sleep(50 * std.time.ns_per_ms);
+    try std.testing.expect(!isAlive(result.pid));
 }
 
 test "terminate non-existent pid does not error" {


### PR DESCRIPTION
## Summary
- report imported standalone `nullclaw/default` status from its live gateway health instead of stale manager runtime state
- include the real standalone port in `/api/status`, `/api/instances`, and instance detail responses when the imported instance is healthy
- ignore zombie PIDs on macOS so defunct processes do not stay falsely `running`

## Why
Imported standalone instances are not managed by the NullHub supervisor in the same way as normal managed instances. Falling back to stale runtime state left `default` misreported as running or stopped with the wrong port, especially when a dead macOS child left behind a zombie PID that `kill(pid, 0)` still treated as alive.

This PR keeps the live-status fix focused on user-visible correctness for both managed and imported standalone setups.

## Validation
- `zig build test -Dbuild-ui=false -Dembed-ui=false`
- live NullHub smoke against `http://127.0.0.1:19800`
- confirmed `/api/status`, `/api/instances`, and `/api/instances/nullclaw/default` report imported standalone `default` from live `/health` on the configured gateway port

## Notes
- this PR is the user-facing split from #38
- the `dev-local` binary staging/refresh behavior is split into a separate follow-up PR