### PR TITLE
fix(instances): refresh staged dev-local binaries

### DIFF
--- a/src/api/instances.zig
+++ b/src/api/instances.zig
@@ -61,6 +61,34 @@ fn readPortFromConfig(allocator: std.mem.Allocator, paths: paths_mod.Paths, comp
     }
 }
 
+fn refreshLocalDevBinary(
+    allocator: std.mem.Allocator,
+    paths: paths_mod.Paths,
+    component: []const u8,
+    version: []const u8,
+) void {
+    if (builtin.is_test) return;
+    if (!std.mem.eql(u8, version, "dev-local")) return;
+
+    const src_bin = local_binary.find(allocator, component) orelse return;
+    defer allocator.free(src_bin);
+
+    const dest_bin = paths.binary(allocator, component, version) catch return;
+    defer allocator.free(dest_bin);
+
+    std_compat.fs.deleteFileAbsolute(dest_bin) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return,
+    };
+    std_compat.fs.copyFileAbsolute(src_bin, dest_bin, .{}) catch return;
+    if (comptime std_compat.fs.has_executable_bit) {
+        if (std_compat.fs.openFileAbsolute(dest_bin, .{ .mode = .read_only })) |f| {
+            defer f.close();
+            f.chmod(0o755) catch {};
+        } else |_| {}
+    }
+}
+
 const FetchedJsonValue = struct {
     bytes: []u8,
     parsed: std.json.Parsed(std.json.Value),
@@ -1920,6 +1948,8 @@ pub fn handleStart(allocator: std.mem.Allocator, s: *state_mod.State, manager: *
             if (pb.value.verbose) |verbose| launch_verbose = verbose;
         }
     }
+
+    refreshLocalDevBinary(allocator, paths, component, entry.version);
 
     // Resolve binary path
     const bin_path = paths.binary(allocator, component, entry.version) catch return helpers.serverError();

--- a/src/core/local_binary.zig
+++ b/src/core/local_binary.zig
@@ -7,19 +7,28 @@ pub fn find(allocator: std.mem.Allocator, component: []const u8) ?[]const u8 {
     const cwd = std_compat.fs.cwd().realpathAlloc(allocator, ".") catch return null;
     defer allocator.free(cwd);
 
-    const candidates = [_][]const []const u8{
-        &.{ cwd, "zig-out", "bin", component },
-        &.{ cwd, component, "zig-out", "bin", component },
-        &.{ cwd, "..", component, "zig-out", "bin", component },
-    };
+    const native_name = std.fmt.allocPrint(allocator, "{s}-native", .{component}) catch return null;
+    defer allocator.free(native_name);
 
-    for (candidates) |parts| {
-        const path = std.fs.path.join(allocator, parts) catch continue;
-        if (std_compat.fs.openFileAbsolute(path, .{})) |f| {
-            f.close();
-            return path;
-        } else |_| {
-            allocator.free(path);
+    const candidate_dirs = [_][]const []const u8{
+        &.{ cwd, "zig-out", "bin" },
+        &.{ cwd, component, "zig-out", "bin" },
+        &.{ cwd, "..", component, "zig-out", "bin" },
+    };
+    const candidate_names = [_][]const u8{ native_name, component };
+
+    for (candidate_dirs) |parts| {
+        const dir_path = std.fs.path.join(allocator, parts) catch continue;
+        defer allocator.free(dir_path);
+
+        for (candidate_names) |name| {
+            const path = std.fs.path.join(allocator, &.{ dir_path, name }) catch continue;
+            if (std_compat.fs.openFileAbsolute(path, .{})) |f| {
+                f.close();
+                return path;
+            } else |_| {
+                allocator.free(path);
+            }
         }
     }
 

--- a/src/core/paths.zig
+++ b/src/core/paths.zig
@@ -62,9 +62,16 @@ pub const Paths = struct {
         return std.fs.path.join(allocator, &.{ self.root, "manifests", filename });
     }
 
-    /// `{root}/bin/{component}-{version}` (or `.exe` on Windows)
+    /// `{root}/bin/{component}-{version}` (or `.exe` on Windows).
+    /// For `dev-local`, use the canonical component basename instead so locally
+    /// staged binaries behave the same as the original executable.
     pub fn binary(self: Paths, allocator: std.mem.Allocator, component: []const u8, version: []const u8) ![]const u8 {
-        const filename = if (builtin.os.tag == .windows)
+        const filename = if (std.mem.eql(u8, version, "dev-local"))
+            if (builtin.os.tag == .windows)
+                try std.fmt.allocPrint(allocator, "{s}.exe", .{component})
+            else
+                try allocator.dupe(u8, component)
+        else if (builtin.os.tag == .windows)
             try std.fmt.allocPrint(allocator, "{s}-{s}.exe", .{ component, version })
         else
             try std.fmt.allocPrint(allocator, "{s}-{s}", .{ component, version });

--- a/src/installer/orchestrator.zig
+++ b/src/installer/orchestrator.zig
@@ -919,10 +919,10 @@ fn stageLocalBinary(allocator: std.mem.Allocator, p: paths_mod.Paths, component:
     const bin_path = p.binary(allocator, component, version) catch return null;
     errdefer allocator.free(bin_path);
 
-    if (downloader.fileExists(bin_path)) {
-        return .{ .version = version, .bin_path = bin_path };
-    }
-
+    std_compat.fs.deleteFileAbsolute(bin_path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return null,
+    };
     std_compat.fs.copyFileAbsolute(local_path, bin_path, .{}) catch return null;
     if (comptime std_compat.fs.has_executable_bit) {
         if (std_compat.fs.openFileAbsolute(bin_path, .{ .mode = .read_only })) |f| {


### PR DESCRIPTION
## Summary
- stage `dev-local` binaries at the canonical `~/.nullhub/bin/<component>` path
- prefer local `zig-out/bin/<component>-native` builds when available
- refresh the staged `dev-local` binary before start so rebuilt local binaries are picked up automatically
- replace stale staged `dev-local` binaries when local contents change

## Why
For local contributor workflows, NullHub could keep launching an outdated staged `dev-local` binary even after the local component had already been rebuilt. That made NullHub-managed local testing pick up stale behavior until the cached binary was deleted manually.

This PR keeps that contributor-oriented `dev-local` workflow fix separate from the broader user-facing runtime-status work.

## Validation
- `zig build test -Dbuild-ui=false -Dembed-ui=false`
- verified staged `dev-local` binaries are refreshed from the rebuilt local binary before managed starts

## Notes
- this PR is the developer-focused split from #38
- user-facing imported-standalone live-status reporting is split into a separate PR