### PR TITLE
fix(runtime): load persisted runtime state safely

### DIFF
--- a/src/supervisor/runtime_state.zig
+++ b/src/supervisor/runtime_state.zig
@@ -16,6 +16,19 @@ pub const PersistedRuntimeView = struct {
     starting_since: ?i64 = null,
 };
 
+const PersistedRuntimeJson = struct {
+    pid: u64 = 0,
+    port: u16 = 0,
+    health_endpoint: []const u8 = "",
+    binary_path: []const u8 = "",
+    working_dir: []const u8 = "",
+    config_path: []const u8 = "",
+    launch_command: []const u8 = "",
+    launch_args: []const []const u8 = &.{},
+    started_at: ?i64 = null,
+    starting_since: ?i64 = null,
+};
+
 pub const PersistedRuntime = struct {
     pid: u64 = 0,
     port: u16 = 0,
@@ -96,14 +109,33 @@ pub fn load(
     const raw = try file.readToEndAlloc(allocator, 64 * 1024);
     defer allocator.free(raw);
 
-    var parsed = try std.json.parseFromSlice(PersistedRuntime, allocator, raw, .{
+    var parsed = try std.json.parseFromSlice(PersistedRuntimeJson, allocator, raw, .{
         .allocate = .alloc_always,
         .ignore_unknown_fields = true,
     });
     defer parsed.deinit();
 
-    var runtime = parsed.value;
-    parsed.value = .{};
+    var runtime = PersistedRuntime{
+        .pid = parsed.value.pid,
+        .port = parsed.value.port,
+        .health_endpoint = try allocator.dupe(u8, parsed.value.health_endpoint),
+        .binary_path = try allocator.dupe(u8, parsed.value.binary_path),
+        .working_dir = try allocator.dupe(u8, parsed.value.working_dir),
+        .config_path = try allocator.dupe(u8, parsed.value.config_path),
+        .launch_command = try allocator.dupe(u8, parsed.value.launch_command),
+        .launch_args = if (parsed.value.launch_args.len == 0)
+            &.{}
+        else
+            try allocator.alloc([]u8, parsed.value.launch_args.len),
+        .started_at = parsed.value.started_at,
+        .starting_since = parsed.value.starting_since,
+    };
+    errdefer runtime.deinit(allocator);
+
+    for (parsed.value.launch_args, 0..) |arg, idx| {
+        runtime.launch_args[idx] = try allocator.dupe(u8, arg);
+    }
+
     if (!runtime.isValid()) {
         runtime.deinit(allocator);
         return error.InvalidRuntimeState;
@@ -160,4 +192,39 @@ test "runtime state round-trips through instance.json" {
 
     delete(allocator, paths, "nullclaw", "demo");
     try std.testing.expect((try load(allocator, paths, "nullclaw", "demo")) == null);
+}
+
+test "load accepts persisted runtime json written by supervisor" {
+    const allocator = std.testing.allocator;
+    const tmp_root = "/tmp/nullhub-test-runtime-state-load";
+    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
+    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
+
+    var paths = try paths_mod.Paths.init(allocator, tmp_root);
+    defer paths.deinit(allocator);
+    try paths.ensureDirs();
+
+    const meta_path = try paths.instanceMeta(allocator, "nullclaw", "demo");
+    defer allocator.free(meta_path);
+    const inst_dir = try paths.instanceDir(allocator, "nullclaw", "demo");
+    defer allocator.free(inst_dir);
+    try fs_compat.makePath(inst_dir);
+
+    const body =
+        "{\"pid\":39275,\"port\":0,\"health_endpoint\":\"/health\",\"binary_path\":\"/Users/vds/.nullhub/bin/nullclaw\",\"working_dir\":\"/Users/vds/.nullhub/instances/nullclaw/demo\",\"config_path\":\"\",\"launch_command\":\"gateway\",\"launch_args\":[\"gateway\"],\"started_at\":1777963594379,\"starting_since\":1777963594379}";
+
+    const file = try std_compat.fs.createFileAbsolute(meta_path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(body);
+
+    var loaded = (try load(allocator, paths, "nullclaw", "demo")).?;
+    defer loaded.deinit(allocator);
+
+    try std.testing.expectEqual(@as(u64, 39275), loaded.pid);
+    try std.testing.expectEqual(@as(u16, 0), loaded.port);
+    try std.testing.expectEqualStrings("/health", loaded.health_endpoint);
+    try std.testing.expectEqualStrings("/Users/vds/.nullhub/bin/nullclaw", loaded.binary_path);
+    try std.testing.expectEqualStrings("gateway", loaded.launch_command);
+    try std.testing.expectEqual(@as(usize, 1), loaded.launch_args.len);
+    try std.testing.expectEqualStrings("gateway", loaded.launch_args[0]);
 }

--- a/src/supervisor/runtime_state.zig
+++ b/src/supervisor/runtime_state.zig
@@ -119,29 +119,47 @@ pub fn load(
     var runtime = PersistedRuntime{
         .pid = parsed.value.pid,
         .port = parsed.value.port,
-        .health_endpoint = try allocator.dupe(u8, parsed.value.health_endpoint),
-        .binary_path = try allocator.dupe(u8, parsed.value.binary_path),
-        .working_dir = try allocator.dupe(u8, parsed.value.working_dir),
-        .config_path = try allocator.dupe(u8, parsed.value.config_path),
-        .launch_command = try allocator.dupe(u8, parsed.value.launch_command),
-        .launch_args = if (parsed.value.launch_args.len == 0)
-            &.{}
-        else
-            try allocator.alloc([]u8, parsed.value.launch_args.len),
+        .health_endpoint = "",
+        .binary_path = "",
+        .working_dir = "",
+        .config_path = "",
+        .launch_command = "",
+        .launch_args = &.{},
         .started_at = parsed.value.started_at,
         .starting_since = parsed.value.starting_since,
     };
     errdefer runtime.deinit(allocator);
 
-    for (parsed.value.launch_args, 0..) |arg, idx| {
-        runtime.launch_args[idx] = try allocator.dupe(u8, arg);
-    }
+    runtime.health_endpoint = try allocator.dupe(u8, parsed.value.health_endpoint);
+    runtime.binary_path = try allocator.dupe(u8, parsed.value.binary_path);
+    runtime.working_dir = try allocator.dupe(u8, parsed.value.working_dir);
+    runtime.config_path = try allocator.dupe(u8, parsed.value.config_path);
+    runtime.launch_command = try allocator.dupe(u8, parsed.value.launch_command);
+    runtime.launch_args = try cloneLaunchArgs(allocator, parsed.value.launch_args);
 
     if (!runtime.isValid()) {
         runtime.deinit(allocator);
         return error.InvalidRuntimeState;
     }
     return runtime;
+}
+
+fn cloneLaunchArgs(allocator: std.mem.Allocator, args: []const []const u8) ![][]u8 {
+    if (args.len == 0) return &.{};
+
+    const owned = try allocator.alloc([]u8, args.len);
+    errdefer allocator.free(owned);
+
+    var cloned: usize = 0;
+    errdefer {
+        for (owned[0..cloned]) |arg| allocator.free(arg);
+    }
+
+    for (args, 0..) |arg, idx| {
+        owned[idx] = try allocator.dupe(u8, arg);
+        cloned += 1;
+    }
+    return owned;
 }
 
 pub fn delete(
@@ -193,17 +211,12 @@ test "runtime state round-trips through instance.json" {
 
 test "load accepts persisted runtime json written by supervisor" {
     const allocator = std.testing.allocator;
-    const tmp_root = "/tmp/nullhub-test-runtime-state-load";
-    std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
-    defer std_compat.fs.deleteTreeAbsolute(tmp_root) catch {};
+    var fixture = try test_helpers.TempPaths.init(allocator);
+    defer fixture.deinit();
 
-    var paths = try paths_mod.Paths.init(allocator, tmp_root);
-    defer paths.deinit(allocator);
-    try paths.ensureDirs();
-
-    const meta_path = try paths.instanceMeta(allocator, "nullclaw", "demo");
+    const meta_path = try fixture.paths.instanceMeta(allocator, "nullclaw", "demo");
     defer allocator.free(meta_path);
-    const inst_dir = try paths.instanceDir(allocator, "nullclaw", "demo");
+    const inst_dir = try fixture.paths.instanceDir(allocator, "nullclaw", "demo");
     defer allocator.free(inst_dir);
     try fs_compat.makePath(inst_dir);
 
@@ -214,7 +227,7 @@ test "load accepts persisted runtime json written by supervisor" {
     defer file.close();
     try file.writeAll(body);
 
-    var loaded = (try load(allocator, paths, "nullclaw", "demo")).?;
+    var loaded = (try load(allocator, fixture.paths, "nullclaw", "demo")).?;
     defer loaded.deinit(allocator);
 
     try std.testing.expectEqual(@as(u64, 39275), loaded.pid);


### PR DESCRIPTION
## Summary
- parse persisted runtime metadata through a read-only JSON shape before copying owned strings into `PersistedRuntime`
- avoid returning slices that still alias the JSON parser arena after `parsed.deinit()`
- add a regression test that loads runtime metadata written in the same JSON form used by the supervisor

## Why
Fresh NullHub builds could crash on boot while reconciling persisted managed runtime state. The loader parsed JSON directly into the owned runtime struct and then deinitialized the parser, leaving fields like `binary_path` and `launch_command` pointing at freed memory. Boot reconciliation then compared those invalid slices and could segfault before the server started.

## Validation
- `zig build test -Dbuild-ui=false -Dembed-ui=false`
- local smoke: rebuilt NullHub booted cleanly and served `/api/status` instead of crashing during reconcile-on-boot