### PR TITLE
fix(ui): avoid resetting instance page on same route

### DIFF
--- a/ui/src/routes/instances/[component]/[name]/+page.svelte
+++ b/ui/src/routes/instances/[component]/[name]/+page.svelte
@@ -97,6 +97,7 @@
   let supportsAgentData = $derived(component === "nullclaw");
   let supportsVerboseStartup = $derived(component === "nullclaw");
   let instanceRouteKey = $derived(`${component}/${name}`);
+  let initializedRouteKey = $state("");
   let queueSummary = $derived(summarizeQueue(integration?.queue));
   let linkedBoilers = $derived(integration?.linked_boilers || []);
   let trackerOptions = $derived(integration?.available_trackers || []);
@@ -580,8 +581,9 @@
   });
 
   $effect(() => {
-    instanceRouteKey;
     if (!component || !name) return;
+    if (initializedRouteKey === instanceRouteKey) return;
+    initializedRouteKey = instanceRouteKey;
     instance = null;
     config = null;
     providerHealth = null;


### PR DESCRIPTION
## Summary
- track the initialized instance route key on the instance detail page
- skip the destructive reset/reload path when reactive updates fire for the same route

## Why
The instance page effect that clears local state and re-runs `refresh(true, true)` was firing even when the route had not actually changed. That caused unnecessary churn on the detail page and regressed the local chat experience by repeatedly clearing instance/config/provider/module state while staying on the same instance.

## Validation
- `npm --prefix ui ci --no-audit --no-fund`
- `npm --prefix ui run build`
- `zig build -Dbuild-ui=false`
- local smoke: chat on the instance page remained working after the rebuild instead of regressing under same-route refreshes