### PR TITLE
v2026.5.29

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .nullhub,
-    .version = "2026.4.17",
+    .version = "2026.5.29",
     .fingerprint = 0x8708b11cb233b548,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{},


### PR DESCRIPTION
Version bump for the v2026.5.29 release.

Changes:
- Update `build.zig.zon` to `2026.5.29`.

Validation:
- `zig fmt --check build.zig.zon`
- `git diff --check`