### PR TITLE
Add MiniMax provider to provider management UI

### DIFF
--- a/src/core/state.zig
+++ b/src/core/state.zig
@@ -73,6 +73,7 @@ pub const SavedChannelUpdate = struct {
 fn providerLabel(provider: []const u8) []const u8 {
     const map = .{
         .{ "openrouter", "OpenRouter" },
+        .{ "minimax", "MiniMax" },
         .{ "anthropic", "Anthropic" },
         .{ "openai", "OpenAI" },
         .{ "google", "Google" },
@@ -1272,13 +1273,15 @@ test "auto-generated name increments per provider type" {
 
     try s.addSavedProvider(.{ .provider = "openrouter", .api_key = "key1" });
     try s.addSavedProvider(.{ .provider = "openrouter", .api_key = "key2" });
-    try s.addSavedProvider(.{ .provider = "anthropic", .api_key = "key3" });
+    try s.addSavedProvider(.{ .provider = "minimax", .api_key = "key3" });
+    try s.addSavedProvider(.{ .provider = "anthropic", .api_key = "key4" });
 
     const providers = s.savedProviders();
-    try std.testing.expectEqual(@as(usize, 3), providers.len);
+    try std.testing.expectEqual(@as(usize, 4), providers.len);
     try std.testing.expectEqualStrings("OpenRouter", providers[0].name);
     try std.testing.expectEqualStrings("OpenRouter #2", providers[1].name);
-    try std.testing.expectEqualStrings("Anthropic", providers[2].name);
+    try std.testing.expectEqualStrings("MiniMax", providers[2].name);
+    try std.testing.expectEqualStrings("Anthropic", providers[3].name);
 }
 
 test "update saved provider name only" {

--- a/ui/src/lib/components/ProviderList.svelte
+++ b/ui/src/lib/components/ProviderList.svelte
@@ -4,8 +4,10 @@
   import {
     OPENAI_COMPATIBLE_VALUE,
     LOCAL_PROVIDERS,
+    PROVIDER_BASE_URL_OPTIONS,
     PROVIDER_DEFAULT_BASE_URLS,
     PROVIDER_DEFAULT_MODELS,
+    mergeProviderModelOptions,
     mergeWithManifestOptions,
     providerUsesOpenAiCompatibleEndpoint,
   } from "$lib/providers";
@@ -89,7 +91,8 @@
   }
 
   function useSaved(sp: any) {
-    const isCompat = sp.base_url && sp.base_url.length > 0;
+    const isNamedEndpointProvider = sp.provider in PROVIDER_DEFAULT_BASE_URLS;
+    const isCompat = Boolean(sp.base_url) && !isNamedEndpointProvider;
     const savedEntry = {
       provider: isCompat ? OPENAI_COMPATIBLE_VALUE : sp.provider,
       api_key: sp.api_key,
@@ -233,7 +236,7 @@
   }
 
   function getModelOptions(entry: ProviderEntry) {
-    return modelOptionsByKey[modelKey(entry)] || [];
+    return mergeProviderModelOptions(entry.provider, modelOptionsByKey[modelKey(entry)] || []);
   }
 
   function getModelError(entry: ProviderEntry) {
@@ -458,7 +461,15 @@
             value={entry.base_url}
             oninput={(e) => updateEntry(i, "base_url", e.currentTarget.value)}
             placeholder={PROVIDER_DEFAULT_BASE_URLS[entry.provider] || "https://api.example.com/v1"}
+            list={`provider-base-url-options-${i}`}
           />
+          {#if PROVIDER_BASE_URL_OPTIONS[entry.provider]?.length}
+            <datalist id={`provider-base-url-options-${i}`}>
+              {#each PROVIDER_BASE_URL_OPTIONS[entry.provider] as option}
+                <option value={option.value}>{option.label}</option>
+              {/each}
+            </datalist>
+          {/if}
         </div>
       {/if}
 
@@ -482,9 +493,7 @@
             {@const filteredModels = getFilteredModels(entry)}
             {@const totalMatches = getFilteredModelCount(entry)}
             <div class="model-dropdown">
-              {#if isModelLoading(entry)}
-                <div class="model-empty">Loading models...</div>
-              {:else if filteredModels.length > 0}
+              {#if filteredModels.length > 0}
                 {#each filteredModels as model}
                   <button
                     type="button"
@@ -503,6 +512,11 @@
                     Showing {filteredModels.length} of {totalMatches}. Keep typing to narrow.
                   </div>
                 {/if}
+                {#if isModelLoading(entry)}
+                  <div class="model-summary">Loading additional models from the endpoint...</div>
+                {/if}
+              {:else if isModelLoading(entry)}
+                <div class="model-empty">Loading models...</div>
               {:else if getModelError(entry)}
                 <div class="model-empty model-error">
                   {getModelError(entry)}. You can still type a model manually.

--- a/ui/src/lib/components/ProviderList.svelte
+++ b/ui/src/lib/components/ProviderList.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
   import { api } from "$lib/api/client";
-  import { OPENAI_COMPATIBLE_VALUE, LOCAL_PROVIDERS, mergeWithManifestOptions } from "$lib/providers";
+  import {
+    OPENAI_COMPATIBLE_VALUE,
+    LOCAL_PROVIDERS,
+    PROVIDER_DEFAULT_BASE_URLS,
+    PROVIDER_DEFAULT_MODELS,
+    mergeWithManifestOptions,
+    providerUsesOpenAiCompatibleEndpoint,
+  } from "$lib/providers";
   import type { ProviderOption } from "$lib/providers";
 
   let {
@@ -176,7 +183,13 @@
       if (provider === OPENAI_COMPATIBLE_VALUE) {
         return { ...e, provider, base_url: e.base_url || "", provider_name: e.provider_name || "" };
       }
-      return { ...e, provider, base_url: "", provider_name: "" };
+      return {
+        ...e,
+        provider,
+        base_url: PROVIDER_DEFAULT_BASE_URLS[provider] || "",
+        model: e.model || PROVIDER_DEFAULT_MODELS[provider] || "",
+        provider_name: "",
+      };
     });
     emitChange();
   }
@@ -233,9 +246,9 @@
 
   async function ensureModelOptions(entry: ProviderEntry) {
     if (!entry.provider) return;
-    // openai-compatible requires a base_url to probe; skip until one is entered.
-    if (entry.provider === OPENAI_COMPATIBLE_VALUE && !entry.base_url) return;
-    if (entry.provider !== OPENAI_COMPATIBLE_VALUE && !component) return;
+    // OpenAI-compatible endpoints require a base_url to probe; skip until one is entered.
+    if (providerUsesOpenAiCompatibleEndpoint(entry.provider) && !entry.base_url) return;
+    if (!providerUsesOpenAiCompatibleEndpoint(entry.provider) && !component) return;
 
     const key = modelKey(entry);
     if (modelLoadingByKey[key] || modelLoadedByKey[key]) return;
@@ -245,7 +258,7 @@
 
     try {
       let models: string[];
-      if (entry.provider === OPENAI_COMPATIBLE_VALUE && entry.base_url) {
+      if (providerUsesOpenAiCompatibleEndpoint(entry.provider) && entry.base_url) {
         const data = await api.probeProviderModels(entry.base_url, entry.api_key || "");
         models = data.live_ok && Array.isArray(data.models) ? data.models : [];
       } else {
@@ -338,6 +351,9 @@
     if (entry.provider === OPENAI_COMPATIBLE_VALUE) {
       return "e.g. gpt-4o-mini";
     }
+    if (entry.provider in PROVIDER_DEFAULT_MODELS) {
+      return PROVIDER_DEFAULT_MODELS[entry.provider];
+    }
     if (entry.provider === "codex-cli" || entry.provider === "openai-codex") {
       return "e.g. gpt-5.4";
     }
@@ -351,7 +367,7 @@
     if (entry.provider === "openai-codex") {
       return "Uses ChatGPT/Codex auth from ~/.codex/auth.json. No API key required here.";
     }
-    if (entry.provider === OPENAI_COMPATIBLE_VALUE) {
+    if (providerUsesOpenAiCompatibleEndpoint(entry.provider)) {
       return "Click to load models from the endpoint, then filter as you type.";
     }
     return "Click to load models, then filter as you type.";
@@ -432,6 +448,8 @@
             placeholder="e.g. infini-ai, xiaomi-mimo"
           />
         </div>
+      {/if}
+      {#if providerUsesOpenAiCompatibleEndpoint(entry.provider)}
         <div class="provider-field">
           <label for={`provider-base-url-${i}`}>Base URL</label>
           <input
@@ -439,7 +457,7 @@
             type="text"
             value={entry.base_url}
             oninput={(e) => updateEntry(i, "base_url", e.currentTarget.value)}
-            placeholder="https://api.example.com/v1"
+            placeholder={PROVIDER_DEFAULT_BASE_URLS[entry.provider] || "https://api.example.com/v1"}
           />
         </div>
       {/if}

--- a/ui/src/lib/providers.ts
+++ b/ui/src/lib/providers.ts
@@ -11,6 +11,7 @@ export type ProviderOption = {
  */
 export const PROVIDER_OPTIONS: ProviderOption[] = [
   { value: "openrouter", label: "OpenRouter (multi-provider, recommended)", recommended: true },
+  { value: "minimax", label: "MiniMax" },
   { value: "anthropic", label: "Anthropic" },
   { value: "openai", label: "OpenAI" },
   { value: "google", label: "Google AI" },
@@ -33,6 +34,18 @@ export const PROVIDER_OPTIONS: ProviderOption[] = [
 export const OPENAI_COMPATIBLE_VALUE = "openai-compatible";
 
 export const LOCAL_PROVIDERS = ["ollama", "lm-studio", "claude-cli", "codex-cli", "openai-codex"];
+
+export const PROVIDER_DEFAULT_BASE_URLS: Record<string, string> = {
+  minimax: "https://api.minimax.io/v1",
+};
+
+export const PROVIDER_DEFAULT_MODELS: Record<string, string> = {
+  minimax: "MiniMax-M3",
+};
+
+export function providerUsesOpenAiCompatibleEndpoint(provider: string) {
+  return provider === OPENAI_COMPATIBLE_VALUE || provider in PROVIDER_DEFAULT_BASE_URLS;
+}
 
 /**
  * Set of all provider values that are NOT the openai-compatible catch-all.

--- a/ui/src/lib/providers.ts
+++ b/ui/src/lib/providers.ts
@@ -35,16 +35,37 @@ export const OPENAI_COMPATIBLE_VALUE = "openai-compatible";
 
 export const LOCAL_PROVIDERS = ["ollama", "lm-studio", "claude-cli", "codex-cli", "openai-codex"];
 
+export type ProviderBaseUrlOption = {
+  value: string;
+  label: string;
+};
+
+export const PROVIDER_BASE_URL_OPTIONS: Record<string, ProviderBaseUrlOption[]> = {
+  minimax: [
+    { value: "https://api.minimax.io/v1", label: "Global" },
+    { value: "https://api.minimaxi.com/v1", label: "China" },
+  ],
+};
+
+export const PROVIDER_MODEL_OPTIONS: Record<string, string[]> = {
+  minimax: ["MiniMax-M3", "MiniMax-M2.7"],
+};
+
 export const PROVIDER_DEFAULT_BASE_URLS: Record<string, string> = {
-  minimax: "https://api.minimax.io/v1",
+  minimax: PROVIDER_BASE_URL_OPTIONS.minimax[0].value,
 };
 
 export const PROVIDER_DEFAULT_MODELS: Record<string, string> = {
-  minimax: "MiniMax-M3",
+  minimax: PROVIDER_MODEL_OPTIONS.minimax[0],
 };
 
 export function providerUsesOpenAiCompatibleEndpoint(provider: string) {
   return provider === OPENAI_COMPATIBLE_VALUE || provider in PROVIDER_DEFAULT_BASE_URLS;
+}
+
+export function mergeProviderModelOptions(provider: string, models: unknown[] = []): string[] {
+  const candidates = [...(PROVIDER_MODEL_OPTIONS[provider] || []), ...models];
+  return [...new Set(candidates.filter((model): model is string => typeof model === "string" && model.length > 0))];
 }
 
 /**

--- a/ui/src/routes/providers/+page.svelte
+++ b/ui/src/routes/providers/+page.svelte
@@ -1,7 +1,15 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
   import { api } from "$lib/api/client";
-  import { PROVIDER_OPTIONS, OPENAI_COMPATIBLE_VALUE, LOCAL_PROVIDERS, KNOWN_PROVIDER_VALUES } from "$lib/providers";
+  import {
+    PROVIDER_OPTIONS,
+    OPENAI_COMPATIBLE_VALUE,
+    LOCAL_PROVIDERS,
+    KNOWN_PROVIDER_VALUES,
+    PROVIDER_DEFAULT_BASE_URLS,
+    PROVIDER_DEFAULT_MODELS,
+    providerUsesOpenAiCompatibleEndpoint,
+  } from "$lib/providers";
 
 
   let providers = $state<any[]>([]);
@@ -107,26 +115,28 @@
     addValidating = true;
     addError = "";
     try {
+      const usesCompatibleEndpoint = providerUsesOpenAiCompatibleEndpoint(addForm.provider);
       const isCustom = addForm.provider === OPENAI_COMPATIBLE_VALUE;
       const providerValue = addForm.provider === OPENAI_COMPATIBLE_VALUE
         ? addForm.provider_name.trim()
         : addForm.provider;
-      const baseUrl = addForm.base_url.trim();
+      const baseUrl = addForm.base_url.trim() || PROVIDER_DEFAULT_BASE_URLS[addForm.provider] || "";
+      const model = addForm.model || PROVIDER_DEFAULT_MODELS[addForm.provider] || undefined;
       if (isCustom && !providerValue) {
         addError = "Provider name is required for OpenAI Compatible providers.";
         addValidating = false;
         return;
       }
-      if (isCustom && !baseUrl) {
-        addError = "Base URL is required for OpenAI Compatible providers.";
+      if (usesCompatibleEndpoint && !baseUrl) {
+        addError = "Base URL is required for this provider.";
         addValidating = false;
         return;
       }
       await api.createSavedProvider({
         provider: providerValue,
         api_key: addForm.api_key,
-        model: addForm.model || undefined,
-        base_url: isCustom ? baseUrl : undefined,
+        model,
+        base_url: usesCompatibleEndpoint ? baseUrl : undefined,
       });
       showAddForm = false;
       addForm = { provider: "openrouter", provider_name: "", api_key: "", model: "", base_url: "" };
@@ -209,7 +219,7 @@
   // A provider is "custom" if its type is not one of the built-in nullclaw-known providers.
   // This determines whether the base_url / Fetch Models fields appear in edit form.
   function isCustomProvider(p: any) {
-    return !KNOWN_PROVIDER_VALUES.has(p.provider);
+    return !KNOWN_PROVIDER_VALUES.has(p.provider) || p.provider in PROVIDER_DEFAULT_BASE_URLS;
   }
 
   function getProviderLabel(value: string) {
@@ -237,7 +247,17 @@
   }
 
   $effect(() => {
-    // Clear probed models when the add form's base_url or api_key changes
+    if (addForm.provider in PROVIDER_DEFAULT_BASE_URLS && !addForm.base_url) {
+      addForm.base_url = PROVIDER_DEFAULT_BASE_URLS[addForm.provider];
+    }
+    if (addForm.provider in PROVIDER_DEFAULT_MODELS && !addForm.model) {
+      addForm.model = PROVIDER_DEFAULT_MODELS[addForm.provider];
+    }
+  });
+
+  $effect(() => {
+    // Clear probed models when the add form's endpoint, key, or provider changes
+    addForm.provider;
     addForm.base_url;
     addForm.api_key;
     addProbedModels = [];
@@ -277,9 +297,16 @@
           <label for="add-provider-name">Provider Name</label>
           <input id="add-provider-name" type="text" bind:value={addForm.provider_name} placeholder="e.g. infini-ai, xiaomi-mimo" />
         </div>
+      {/if}
+      {#if providerUsesOpenAiCompatibleEndpoint(addForm.provider)}
         <div class="field">
           <label for="add-base-url">Base URL</label>
-          <input id="add-base-url" type="text" bind:value={addForm.base_url} placeholder="https://api.example.com/v1" />
+          <input
+            id="add-base-url"
+            type="text"
+            bind:value={addForm.base_url}
+            placeholder={PROVIDER_DEFAULT_BASE_URLS[addForm.provider] || "https://api.example.com/v1"}
+          />
         </div>
       {/if}
       {#if !isLocal(addForm.provider)}
@@ -288,11 +315,16 @@
           <input id="add-api-key" type="password" bind:value={addForm.api_key} placeholder="Enter API key..." />
         </div>
       {/if}
-      {#if addForm.provider === OPENAI_COMPATIBLE_VALUE}
+      {#if providerUsesOpenAiCompatibleEndpoint(addForm.provider)}
         <div class="field">
           <label for="add-model">Model</label>
           <div class="model-input-row">
-            <input id="add-model" type="text" bind:value={addForm.model} placeholder="e.g. gpt-4" />
+            <input
+              id="add-model"
+              type="text"
+              bind:value={addForm.model}
+              placeholder={PROVIDER_DEFAULT_MODELS[addForm.provider] || "e.g. gpt-4"}
+            />
             <button
               class="btn fetch-models-btn"
               onclick={fetchAddModels}

--- a/ui/src/routes/providers/+page.svelte
+++ b/ui/src/routes/providers/+page.svelte
@@ -6,8 +6,10 @@
     OPENAI_COMPATIBLE_VALUE,
     LOCAL_PROVIDERS,
     KNOWN_PROVIDER_VALUES,
+    PROVIDER_BASE_URL_OPTIONS,
     PROVIDER_DEFAULT_BASE_URLS,
     PROVIDER_DEFAULT_MODELS,
+    mergeProviderModelOptions,
     providerUsesOpenAiCompatibleEndpoint,
   } from "$lib/providers";
 
@@ -246,14 +248,12 @@
     return provider.last_validation_at || provider.validated_at || "";
   }
 
-  $effect(() => {
-    if (addForm.provider in PROVIDER_DEFAULT_BASE_URLS && !addForm.base_url) {
-      addForm.base_url = PROVIDER_DEFAULT_BASE_URLS[addForm.provider];
-    }
-    if (addForm.provider in PROVIDER_DEFAULT_MODELS && !addForm.model) {
-      addForm.model = PROVIDER_DEFAULT_MODELS[addForm.provider];
-    }
-  });
+  function selectAddProvider(provider: string) {
+    addForm.provider = provider;
+    addForm.provider_name = "";
+    addForm.base_url = PROVIDER_DEFAULT_BASE_URLS[provider] || "";
+    addForm.model = PROVIDER_DEFAULT_MODELS[provider] || "";
+  }
 
   $effect(() => {
     // Clear probed models when the add form's endpoint, key, or provider changes
@@ -282,11 +282,12 @@
   {/if}
 
   {#if showAddForm}
+    {@const addModelOptions = mergeProviderModelOptions(addForm.provider, addProbedModels)}
     <div class="add-form">
       <h2>Add Provider</h2>
       <div class="field">
         <label for="add-provider">Provider</label>
-        <select id="add-provider" bind:value={addForm.provider}>
+        <select id="add-provider" value={addForm.provider} onchange={(event) => selectAddProvider(event.currentTarget.value)}>
           {#each PROVIDER_OPTIONS as opt}
             <option value={opt.value}>{opt.label}</option>
           {/each}
@@ -306,7 +307,15 @@
             type="text"
             bind:value={addForm.base_url}
             placeholder={PROVIDER_DEFAULT_BASE_URLS[addForm.provider] || "https://api.example.com/v1"}
+            list="add-provider-base-url-options"
           />
+          {#if PROVIDER_BASE_URL_OPTIONS[addForm.provider]?.length}
+            <datalist id="add-provider-base-url-options">
+              {#each PROVIDER_BASE_URL_OPTIONS[addForm.provider] as option}
+                <option value={option.value}>{option.label}</option>
+              {/each}
+            </datalist>
+          {/if}
         </div>
       {/if}
       {#if !isLocal(addForm.provider)}
@@ -337,9 +346,9 @@
           {#if addProbeError}
             <div class="probe-error">{addProbeError}</div>
           {/if}
-          {#if addProbedModels.length > 0}
+          {#if addModelOptions.length > 0}
             <div class="model-list">
-              {#each addProbedModels as m}
+              {#each addModelOptions as m}
                 <button
                   class="model-chip"
                   class:selected={addForm.model === m}
@@ -375,6 +384,7 @@
       {#each providers as p}
         <div class="provider-card">
           {#if editingId === p.id}
+            {@const editModelOptions = mergeProviderModelOptions(p.provider, editProbedModels)}
             <div class="edit-form">
               <div class="field">
                 <label for="edit-name-{p.id}">Name</label>
@@ -383,7 +393,20 @@
               {#if isCustomProvider(p)}
                 <div class="field">
                   <label for="edit-base-url-{p.id}">Base URL</label>
-                  <input id="edit-base-url-{p.id}" type="text" bind:value={editForm.base_url} placeholder="https://api.example.com/v1" />
+                  <input
+                    id="edit-base-url-{p.id}"
+                    type="text"
+                    bind:value={editForm.base_url}
+                    placeholder={PROVIDER_DEFAULT_BASE_URLS[p.provider] || "https://api.example.com/v1"}
+                    list={`edit-provider-base-url-options-${p.id}`}
+                  />
+                  {#if PROVIDER_BASE_URL_OPTIONS[p.provider]?.length}
+                    <datalist id={`edit-provider-base-url-options-${p.id}`}>
+                      {#each PROVIDER_BASE_URL_OPTIONS[p.provider] as option}
+                        <option value={option.value}>{option.label}</option>
+                      {/each}
+                    </datalist>
+                  {/if}
                 </div>
               {/if}
               {#if !isLocal(p.provider)}
@@ -396,7 +419,12 @@
                 <label for="edit-model-{p.id}">Model</label>
                 {#if isCustomProvider(p)}
                   <div class="model-input-row">
-                    <input id="edit-model-{p.id}" type="text" bind:value={editForm.model} placeholder="e.g. gpt-4" />
+                    <input
+                      id="edit-model-{p.id}"
+                      type="text"
+                      bind:value={editForm.model}
+                      placeholder={PROVIDER_DEFAULT_MODELS[p.provider] || "e.g. gpt-4"}
+                    />
                     <button
                       class="btn fetch-models-btn"
                       onclick={fetchEditModels}
@@ -409,9 +437,9 @@
                   {#if editProbeError}
                     <div class="probe-error">{editProbeError}</div>
                   {/if}
-                  {#if editProbedModels.length > 0}
+                  {#if editModelOptions.length > 0}
                     <div class="model-list">
-                      {#each editProbedModels as m}
+                      {#each editModelOptions as m}
                         <button
                           class="model-chip"
                           class:selected={editForm.model === m}


### PR DESCRIPTION
Reason: Add MiniMax as a first-class OpenAI-compatible provider with its default endpoint and current model.

This change adds MiniMax to the provider selector, applies its global endpoint and default model, and treats it as an OpenAI-compatible endpoint for model probing and saved-provider forms. It also adds the MiniMax provider label while preserving the existing provider naming coverage.

Checks:
- `zig build test -Dembed-ui=false`
- `npm run build` (in `ui`)
- `git diff --check`
- Secret scan
